### PR TITLE
Set the first boot menu entry as default when using BLS fragments

### DIFF
--- a/util/grub.d/10_linux.in
+++ b/util/grub.d/10_linux.in
@@ -149,6 +149,7 @@ if [ -s \$prefix/grubenv ]; then
 fi
 EOF
 
+    ${grub_editenv} - set saved_entry=0
     ${grub_editenv} - set kernelopts="root=${linux_root_device_thisversion} ro ${args}"
 
     exit 0


### PR DESCRIPTION
When BootLoaderSpec configuration files are used, the default boot menu
entry is always set to the first entry as sorted by the blscfg command.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>