### PR TITLE
Ensure correct /sys/block path

### DIFF
--- a/util/grub.d/30_os-prober.in
+++ b/util/grub.d/30_os-prober.in
@@ -231,7 +231,7 @@ EOF
 	used_osprober_linux_ids="$used_osprober_linux_ids 'osprober-gnulinux-$LKERNEL-${recovery_params}-$counter-$boot_device_id'"
 
 	if [ -z "${prepare_boot_cache}" ]; then
-	  prepare_boot_cache="$(prepare_grub_to_access_device ${LBOOT} | grub_add_tab)"
+	  prepare_boot_cache="$(prepare_grub_to_access_device ${LBOOT}:${LLABEL} | grub_add_tab)"
 	fi
 
 	if [ "x$is_top_level" = xtrue ] && [ "x${GRUB_DISABLE_SUBMENU}" != xy ]; then


### PR DESCRIPTION
LBOOT and LLABEL are cut from contents of ${LINUXPROBED}.

+ LINUXPROBED='/dev/mapper/vg00alt-rootvol:/dev/block/8:2[..]
++ cut -d : -f 2
+ LBOOT=/dev/block/8
++ cut -d : -f 3
+ LLABEL=2

 However, only ${LBOOT} is referenced here:

        if [ -z "${prepare_boot_cache}" ]; then
          prepare_boot_cache="$(prepare_grub_to_access_device ${LBOOT} | grub_add_tab)"
        fi

A true condition results in an incorrectly referenced device and returns grub2-probe error:

++ prepare_grub_to_access_device /dev/block/8
++ /usr/sbin/grub2-probe: error: cannot find a GRUB drive for /dev/block/8.  Check your device.map.

Make sure device is in form of ${LBOOT}:${LLABEL}

Signed-off-by: Jon Magrini <jmagrini@redhat.com>