### PR TITLE
Some stuff that was missing in the grub2-switch-to-blscfg script

### DIFF
--- a/util/grub-switch-to-blscfg.8
+++ b/util/grub-switch-to-blscfg.8
@@ -21,5 +21,13 @@ The grub config file to use.  The default value is \fI/etc/grub2-efi.cfg\fR on U
 --grub-defaults=\fIFILE\fR
 The defaults file for grub-mkconfig.  The default value is \fI/etc/default/grub\fR.
 
+.TP
+--bls-directory=\fIDIR\fR
+Create BootLoaderSpec fragments in \fIDIR\fR.  The default value is \fI/boot/loader/entries\fR on BIOS machines and \fI/boot/efi/EFI/\fBVENDOR\fI/loader/entries\fR on UEFI machines.
+
+.TP
+--backup-suffix=\fSUFFIX\fR
+The suffix to use for saved backup files.  The default value is \fI.bak\fR.
+
 .SH SEE ALSO
 .BR "info grub"

--- a/util/grub-switch-to-blscfg.in
+++ b/util/grub-switch-to-blscfg.in
@@ -252,7 +252,7 @@ if [[ "${GENERATE}" -eq 1 ]] ; then
         cp -af "${GRUB_CONFIG_FILE}${backupsuffix}" "${GRUB_CONFIG_FILE}"
         sed -i"${backupsuffix}" \
             -e 's,^GRUB_ENABLE_BLSCFG=.*,GRUB_ENABLE_BLSCFG=false,' \
-            /etc/default/grub
+            "${etcdefaultgrub}"
         gettext_printf "Updating %s failed\n" "${GRUB_CONFIG_FILE}"
         exit 1
     fi

--- a/util/grub-switch-to-blscfg.in
+++ b/util/grub-switch-to-blscfg.in
@@ -44,7 +44,7 @@ if [ -d /sys/firmware/efi/efivars/ ]; then
 else
     startlink=/etc/grub2.cfg
     grubdir=`echo "/@bootdirname@/@grubdirname@" | sed 's,//*,/,g'`
-    blsdir=`echo "/@bootdirname@" | sed 's,//*,/,g'`
+    blsdir=`echo "/@bootdirname@/loader/entries" | sed 's,//*,/,g'`
 fi
 
 backupsuffix=.bak

--- a/util/grub-switch-to-blscfg.in
+++ b/util/grub-switch-to-blscfg.in
@@ -21,6 +21,7 @@
 # Initialize some variables.
 prefix=@prefix@
 exec_prefix=@exec_prefix@
+sbindir=@sbindir@
 bindir=@bindir@
 sysconfdir="@sysconfdir@"
 PACKAGE_NAME=@PACKAGE_NAME@
@@ -33,8 +34,11 @@ fi
 
 self=`basename $0`
 
+grub_get_kernel_settings="${sbindir}/@grub_get_kernel_settings@"
 grub_editenv=${bindir}/@grub_editenv@
 etcdefaultgrub=/etc/default/grub
+
+eval "$("${grub_get_kernel_settings}")" || true
 
 EFIDIR=$(grep ^ID= /etc/os-release | sed -e 's/^ID=//' -e 's/rhel/redhat/')
 if [ -d /sys/firmware/efi/efivars/ ]; then
@@ -225,6 +229,17 @@ for kernelver in $(cd /lib/modules/ ; ls -1) "" ; do
         mkbls "${kernelver}" \
             "$(date -u +%Y%m%d%H%M%S -d "$(stat -c '%y' "${kernel_dir}")")" \
             >"${bls_target}"
+    fi
+
+    if [ "x$GRUB_LINUX_MAKE_DEBUG" = "xtrue" ]; then
+        arch="$(uname -m)"
+        bls_debug="$(echo ${bls_target} | sed -e "s/\.${arch}/-debug.${arch}/")"
+        cp -aT  "${bls_target}" "${bls_debug}"
+        title="$(grep '^title[ \t]' "${bls_debug}" | sed -e 's/^title[ \t]*//')"
+        blsid="$(grep '^id[ \t]' "${bls_debug}" | sed -e "s/\.${ARCH}/-debug.${arch}/")"
+        sed -i -e "s/^title.*/title ${title}${GRUB_LINUX_DEBUG_TITLE_POSTFIX}/" "${bls_debug}"
+        sed -i -e "s/^id.*/${blsid}/" "${bls_debug}"
+        sed -i -e "s/^options.*/options \$kernelopts ${GRUB_CMDLINE_LINUX_DEBUG}/" "${bls_debug}"
     fi
 done
 

--- a/util/grub-switch-to-blscfg.in
+++ b/util/grub-switch-to-blscfg.in
@@ -243,6 +243,10 @@ for kernelver in $(cd /lib/modules/ ; ls -1) "" ; do
     fi
 done
 
+if [[ -f "/boot/vmlinuz-0-rescue-${MACHINE_ID}" ]]; then
+    mkbls "0-rescue-${MACHINE_ID}" "0" >"${blsdir}/${MACHINE_ID}-0-rescue.conf"
+fi
+
 GENERATE=0
 if grep '^GRUB_ENABLE_BLSCFG=.*' "${etcdefaultgrub}" \
         | grep -vq '^GRUB_ENABLE_BLSCFG="*true"*\s*$' ; then


### PR DESCRIPTION
This pull request contains some stuff that was missing in the grub2-switch-to-blscfg script, namely:

* Document some options that weren't in the script's man page.
* Generate debug BLS fragments if `MAKDEBUG=yes` in `/etc/sysconfig/kernel`.
* Generate a BLS fragment for the rescue image if there's one in the `/boot` directory.