### PR TITLE
Use BLS version field to compare entries if id field isn't defined

### DIFF
--- a/grub-core/commands/blscfg.c
+++ b/grub-core/commands/blscfg.c
@@ -419,6 +419,9 @@ static int bls_cmp(const void *p0, const void *p1, void *state UNUSED)
   rc = bls_keyval_cmp (e0, e1, "id");
 
   if (rc == 0)
+    rc = bls_keyval_cmp (e0, e1, "version");
+
+  if (rc == 0)
     rc = bls_keyval_cmp (e0, e1, "title");
 
   if (rc == 0)


### PR DESCRIPTION
The BootLoaderSpec fragments generated by OSTree don't have the id field,
so grub2 will attempt to sort the entries by using the title field which
may not be correct. The entries do have a version field though so use it.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>