### PR TITLE
Fix BLS entry fields not being present in grub2 menu entry or in the wrong order

### DIFF
--- a/include/grub/kernel.h
+++ b/include/grub/kernel.h
@@ -108,8 +108,10 @@ grub_addr_t grub_modules_get_end (void);
 
 #endif
 
+#if !defined(GRUB_MACHINE_EMU)
 void EXPORT_FUNC(start) (void);
 void EXPORT_FUNC(_start) (void);
+#endif
 
 /* The start point of the C code.  */
 void grub_main (void) __attribute__ ((noreturn));


### PR DESCRIPTION
This pull request simplify BLS entry key val pairs lookup and also fixes issues that caused the BLS fields not being present in the grub2 menu entries or being present but in the wrong order.

The first commit is just a trivial fix that allows grub-emu to build, having grub-emu in a buildable state is useful for testing and development purposes. The second patch is the one that fixes the issues.