### PR TITLE
Menu auto hide

### DIFF
--- a/Makefile.util.def
+++ b/Makefile.util.def
@@ -1422,3 +1422,10 @@ program = {
   ldadd = grub-core/gnulib/libgnu.a;
   ldadd = '$(LIBINTL) $(LIBDEVMAPPER) $(LIBZFS) $(LIBNVPAIR) $(LIBGEOM)';
 };
+
+program = {
+  name = grub-set-bootflag;
+  installdir = sbin;
+  mansection = 1;
+  common = util/grub-set-bootflag.c;
+};

--- a/Makefile.util.def
+++ b/Makefile.util.def
@@ -523,6 +523,12 @@ script = {
 };
 
 script = {
+  name = '30_uefi-firmware';
+  common = util/grub.d/30_uefi-firmware.in;
+  installdir = grubconf;
+};
+
+script = {
   name = '40_custom';
   common = util/grub.d/40_custom.in;
   installdir = grubconf;

--- a/Makefile.util.def
+++ b/Makefile.util.def
@@ -442,6 +442,12 @@ script = {
 };
 
 script = {
+  name = '00_menu_auto_hide';
+  common = util/grub.d/00_menu_auto_hide.in;
+  installdir = grubconf;
+};
+
+script = {
   name = '01_users';
   common = util/grub.d/01_users.in;
   installdir = grubconf;

--- a/conf/Makefile.extra-dist
+++ b/conf/Makefile.extra-dist
@@ -14,6 +14,9 @@ EXTRA_DIST += util/import_unicode.py
 EXTRA_DIST += docs/autoiso.cfg
 EXTRA_DIST += docs/grub.cfg
 EXTRA_DIST += docs/osdetect.cfg
+EXTRA_DIST += docs/org.gnu.grub.policy
+EXTRA_DIST += docs/grub-boot-success.service
+EXTRA_DIST += docs/grub-boot-success.timer
 
 EXTRA_DIST += conf/i386-cygwin-img-ld.sc
 

--- a/docs/grub-boot-success.service
+++ b/docs/grub-boot-success.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Mark boot as successful
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/pkexec /usr/sbin/grub2-set-bootflag boot_success

--- a/docs/grub-boot-success.timer
+++ b/docs/grub-boot-success.timer
@@ -1,0 +1,5 @@
+[Unit]
+Description=Mark boot as successful after the user session has run 2 minutes
+
+[Timer]
+OnActiveSec=2min

--- a/docs/org.gnu.grub.policy
+++ b/docs/org.gnu.grub.policy
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN" "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <vendor>GNU GRUB</vendor>
+  <vendor_url>https://www.gnu.org/software/grub/</vendor_url>
+  <action id="org.gnu.grub.set-bootflag">
+    <!-- SECURITY:
+          - A normal active user on the local machine does not need permission
+            to set bootflags to show the menu / mark current boot successful.
+     -->
+    <description>Set GRUB bootflags</description>
+    <message>Authentication is required to modify the bootloaders bootflags</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/sbin/grub2-set-bootflag</annotate>
+  </action>
+</policyconfig>

--- a/grub-core/commands/keystatus.c
+++ b/grub-core/commands/keystatus.c
@@ -35,24 +35,6 @@ static const struct grub_arg_option options[] =
     {0, 0, 0, 0, 0, 0}
   };
 
-static int
-grub_getkeystatus (void)
-{
-  int status = 0;
-  grub_term_input_t term;
-
-  if (grub_term_poll_usb)
-    grub_term_poll_usb (0);
-
-  FOR_ACTIVE_TERM_INPUTS(term)
-  {
-    if (term->getkeystatus)
-      status |= term->getkeystatus (term);
-  }
-
-  return status;
-}
-
 static grub_err_t
 grub_cmd_keystatus (grub_extcmd_context_t ctxt,
 		    int argc __attribute__ ((unused)),

--- a/grub-core/commands/sleep.c
+++ b/grub-core/commands/sleep.c
@@ -55,7 +55,7 @@ grub_interruptible_millisleep (grub_uint32_t ms)
   start = grub_get_time_ms ();
 
   while (grub_get_time_ms () - start < ms)
-    if (grub_getkey_noblock () == GRUB_TERM_ESC)
+    if (grub_key_is_interrupt (grub_getkey_noblock ()))
       return 1;
 
   return 0;

--- a/grub-core/kern/term.c
+++ b/grub-core/kern/term.c
@@ -138,6 +138,22 @@ grub_getkeystatus (void)
   return status;
 }
 
+int
+grub_key_is_interrupt (int key)
+{
+  /* ESC sometimes is the BIOS setup hotkey and may be hard to discover, also
+     check F8, which was the key to get the Windows bootmenu for a long time. */
+  if (key == GRUB_TERM_ESC || key == GRUB_TERM_KEY_F8)
+    return 1;
+
+  /* Pressing keys at the right time during boot is hard to time, also allow
+     interrupting sleeps / the menu countdown by keeping shift pressed. */
+  if (grub_getkeystatus() & (GRUB_TERM_STATUS_LSHIFT|GRUB_TERM_STATUS_RSHIFT))
+    return 1;
+
+  return 0;
+}
+
 void
 grub_refresh (void)
 {

--- a/grub-core/kern/term.c
+++ b/grub-core/kern/term.c
@@ -120,6 +120,24 @@ grub_getkey (void)
     }
 }
 
+int
+grub_getkeystatus (void)
+{
+  int status = 0;
+  grub_term_input_t term;
+
+  if (grub_term_poll_usb)
+    grub_term_poll_usb (0);
+
+  FOR_ACTIVE_TERM_INPUTS(term)
+  {
+    if (term->getkeystatus)
+      status |= term->getkeystatus (term);
+  }
+
+  return status;
+}
+
 void
 grub_refresh (void)
 {

--- a/grub-core/normal/menu.c
+++ b/grub-core/normal/menu.c
@@ -655,7 +655,7 @@ run_menu (grub_menu_t menu, int nested, int *auto_boot)
 	      if (entry >= 0)
 		break;
 	    }
-	  if (key == GRUB_TERM_ESC)
+	  if (grub_key_is_interrupt (key))
 	    {
 	      timeout = -1;
 	      break;

--- a/grub-core/term/efi/console.c
+++ b/grub-core/term/efi/console.c
@@ -220,6 +220,39 @@ grub_console_getkey_ex(struct grub_term_input *term)
   return key;
 }
 
+static int
+grub_console_getkeystatus(struct grub_term_input *term)
+{
+  grub_efi_key_data_t key_data;
+  grub_efi_uint32_t kss;
+  int key, mods = 0;
+
+  if (grub_efi_is_finished)
+    return 0;
+
+  if (grub_console_read_key_stroke (term->data, &key_data, &key, 0))
+    return 0;
+
+  kss = key_data.key_state.key_shift_state;
+  if (kss & GRUB_EFI_SHIFT_STATE_VALID)
+    {
+      if (kss & GRUB_EFI_LEFT_SHIFT_PRESSED)
+        mods |= GRUB_TERM_STATUS_LSHIFT;
+      if (kss & GRUB_EFI_RIGHT_SHIFT_PRESSED)
+        mods |= GRUB_TERM_STATUS_RSHIFT;
+      if (kss & GRUB_EFI_LEFT_ALT_PRESSED)
+        mods |= GRUB_TERM_STATUS_LALT;
+      if (kss & GRUB_EFI_RIGHT_ALT_PRESSED)
+        mods |= GRUB_TERM_STATUS_RALT;
+      if (kss & GRUB_EFI_LEFT_CONTROL_PRESSED)
+        mods |= GRUB_TERM_STATUS_LCTRL;
+      if (kss & GRUB_EFI_RIGHT_CONTROL_PRESSED)
+        mods |= GRUB_TERM_STATUS_RCTRL;
+    }
+
+  return mods;
+}
+
 static grub_err_t
 grub_efi_console_input_init (struct grub_term_input *term)
 {
@@ -400,6 +433,7 @@ static struct grub_term_input grub_console_term_input =
   {
     .name = "console",
     .getkey = grub_console_getkey,
+    .getkeystatus = grub_console_getkeystatus,
     .init = grub_efi_console_input_init,
   };
 

--- a/grub-core/term/efi/console.c
+++ b/grub-core/term/efi/console.c
@@ -24,6 +24,11 @@
 #include <grub/efi/api.h>
 #include <grub/efi/console.h>
 
+static grub_err_t grub_prepare_for_text_output(struct grub_term_output *term);
+
+static int text_mode_available = -1;
+static int text_colorstate = -1;
+
 static grub_uint32_t
 map_char (grub_uint32_t c)
 {
@@ -66,14 +71,14 @@ map_char (grub_uint32_t c)
 }
 
 static void
-grub_console_putchar (struct grub_term_output *term __attribute__ ((unused)),
+grub_console_putchar (struct grub_term_output *term,
 		      const struct grub_unicode_glyph *c)
 {
   grub_efi_char16_t str[2 + 30];
   grub_efi_simple_text_output_interface_t *o;
   unsigned i, j;
 
-  if (grub_efi_is_finished)
+  if (grub_prepare_for_text_output (term))
     return;
 
   o = grub_efi_system_table->con_out;
@@ -220,14 +225,15 @@ grub_console_getkey (struct grub_term_input *term)
 }
 
 static struct grub_term_coordinate
-grub_console_getwh (struct grub_term_output *term __attribute__ ((unused)))
+grub_console_getwh (struct grub_term_output *term)
 {
   grub_efi_simple_text_output_interface_t *o;
   grub_efi_uintn_t columns, rows;
 
   o = grub_efi_system_table->con_out;
-  if (grub_efi_is_finished || efi_call_4 (o->query_mode, o, o->mode->mode,
-					  &columns, &rows) != GRUB_EFI_SUCCESS)
+  if (grub_prepare_for_text_output (term) != GRUB_ERR_NONE ||
+      efi_call_4 (o->query_mode, o, o->mode->mode,
+		  &columns, &rows) != GRUB_EFI_SUCCESS)
     {
       /* Why does this fail?  */
       columns = 80;
@@ -242,7 +248,7 @@ grub_console_getxy (struct grub_term_output *term __attribute__ ((unused)))
 {
   grub_efi_simple_text_output_interface_t *o;
 
-  if (grub_efi_is_finished)
+  if (grub_efi_is_finished || text_mode_available != 1)
     return (struct grub_term_coordinate) { 0, 0 };
 
   o = grub_efi_system_table->con_out;
@@ -250,12 +256,12 @@ grub_console_getxy (struct grub_term_output *term __attribute__ ((unused)))
 }
 
 static void
-grub_console_gotoxy (struct grub_term_output *term __attribute__ ((unused)),
+grub_console_gotoxy (struct grub_term_output *term,
 		     struct grub_term_coordinate pos)
 {
   grub_efi_simple_text_output_interface_t *o;
 
-  if (grub_efi_is_finished)
+  if (grub_prepare_for_text_output (term))
     return;
 
   o = grub_efi_system_table->con_out;
@@ -268,7 +274,7 @@ grub_console_cls (struct grub_term_output *term __attribute__ ((unused)))
   grub_efi_simple_text_output_interface_t *o;
   grub_efi_int32_t orig_attr;
 
-  if (grub_efi_is_finished)
+  if (grub_efi_is_finished || text_mode_available != 1)
     return;
 
   o = grub_efi_system_table->con_out;
@@ -287,6 +293,12 @@ grub_console_setcolorstate (struct grub_term_output *term
 
   if (grub_efi_is_finished)
     return;
+
+  if (text_mode_available != 1) {
+    /* Avoid "color_normal" environment writes causing a switch to textmode */
+    text_colorstate = state;
+    return;
+  }
 
   o = grub_efi_system_table->con_out;
 
@@ -312,7 +324,7 @@ grub_console_setcursor (struct grub_term_output *term __attribute__ ((unused)),
 {
   grub_efi_simple_text_output_interface_t *o;
 
-  if (grub_efi_is_finished)
+  if (grub_efi_is_finished || text_mode_available != 1)
     return;
 
   o = grub_efi_system_table->con_out;
@@ -320,18 +332,38 @@ grub_console_setcursor (struct grub_term_output *term __attribute__ ((unused)),
 }
 
 static grub_err_t
-grub_efi_console_output_init (struct grub_term_output *term)
+grub_prepare_for_text_output(struct grub_term_output *term)
 {
-  grub_efi_set_text_mode (1);
+  if (grub_efi_is_finished)
+    return GRUB_ERR_BAD_DEVICE;
+
+  if (text_mode_available != -1)
+    return text_mode_available ? 0 : GRUB_ERR_BAD_DEVICE;
+
+  if (! grub_efi_set_text_mode (1))
+    {
+      /* This really should never happen */
+      grub_error (GRUB_ERR_BAD_DEVICE, "cannot set text mode");
+      text_mode_available = 0;
+      return GRUB_ERR_BAD_DEVICE;
+    }
+
   grub_console_setcursor (term, 1);
+  if (text_colorstate != -1)
+    grub_console_setcolorstate (term, text_colorstate);
+  text_mode_available = 1;
   return 0;
 }
 
 static grub_err_t
 grub_efi_console_output_fini (struct grub_term_output *term)
 {
+  if (text_mode_available != 1)
+    return 0;
+
   grub_console_setcursor (term, 0);
   grub_efi_set_text_mode (0);
+  text_mode_available = -1;
   return 0;
 }
 
@@ -345,7 +377,6 @@ static struct grub_term_input grub_console_term_input =
 static struct grub_term_output grub_console_term_output =
   {
     .name = "console",
-    .init = grub_efi_console_output_init,
     .fini = grub_efi_console_output_fini,
     .putchar = grub_console_putchar,
     .getwh = grub_console_getwh,
@@ -361,14 +392,6 @@ static struct grub_term_output grub_console_term_output =
 void
 grub_console_init (void)
 {
-  /* FIXME: it is necessary to consider the case where no console control
-     is present but the default is already in text mode.  */
-  if (! grub_efi_set_text_mode (1))
-    {
-      grub_error (GRUB_ERR_BAD_DEVICE, "cannot set text mode");
-      return;
-    }
-
   grub_term_register_output ("console", &grub_console_term_output);
   grub_term_register_input ("console", &grub_console_term_input);
 }

--- a/grub-core/term/efi/console.c
+++ b/grub-core/term/efi/console.c
@@ -154,27 +154,56 @@ grub_console_getkey_con (struct grub_term_input *term __attribute__ ((unused)))
   return grub_efi_translate_key(key);
 }
 
+/*
+ * When more then just modifiers are pressed, our getkeystatus() consumes a
+ * press from the queue, this function buffers the press for the regular
+ * getkey() so that it does not get lost.
+ */
+static int
+grub_console_read_key_stroke (
+                   grub_efi_simple_text_input_ex_interface_t *text_input,
+                   grub_efi_key_data_t *key_data_ret, int *key_ret,
+                   int consume)
+{
+  static grub_efi_key_data_t key_data;
+  grub_efi_status_t status;
+  int key;
+
+  if (!text_input)
+    return GRUB_ERR_EOF;
+
+  key = grub_efi_translate_key (key_data.key);
+  if (key == GRUB_TERM_NO_KEY) {
+    status = efi_call_2 (text_input->read_key_stroke, text_input, &key_data);
+    if (status != GRUB_EFI_SUCCESS)
+      return GRUB_ERR_EOF;
+
+    key = grub_efi_translate_key (key_data.key);
+  }
+
+  *key_data_ret = key_data;
+  *key_ret = key;
+
+  if (consume) {
+    key_data.key.scan_code = 0;
+    key_data.key.unicode_char = 0;
+  }
+
+  return 0;
+}
+
 static int
 grub_console_getkey_ex(struct grub_term_input *term)
 {
   grub_efi_key_data_t key_data;
-  grub_efi_status_t status;
   grub_efi_uint32_t kss;
   int key = -1;
 
-  grub_efi_simple_text_input_ex_interface_t *text_input = term->data;
-
-  status = efi_call_2 (text_input->read_key_stroke, text_input, &key_data);
-
-  if (status != GRUB_EFI_SUCCESS)
+  if (grub_console_read_key_stroke (term->data, &key_data, &key, 1) ||
+      key == GRUB_TERM_NO_KEY)
     return GRUB_TERM_NO_KEY;
 
   kss = key_data.key_state.key_shift_state;
-  key = grub_efi_translate_key(key_data.key);
-
-  if (key == GRUB_TERM_NO_KEY)
-    return GRUB_TERM_NO_KEY;
-
   if (kss & GRUB_EFI_SHIFT_STATE_VALID)
     {
       if ((kss & GRUB_EFI_LEFT_SHIFT_PRESSED

--- a/include/grub/term.h
+++ b/include/grub/term.h
@@ -328,6 +328,7 @@ void grub_putcode (grub_uint32_t code, struct grub_term_output *term);
 int EXPORT_FUNC(grub_getkey) (void);
 int EXPORT_FUNC(grub_getkey_noblock) (void);
 int EXPORT_FUNC(grub_getkeystatus) (void);
+int EXPORT_FUNC(grub_key_is_interrupt) (int key);
 void grub_cls (void);
 void EXPORT_FUNC(grub_refresh) (void);
 void grub_puts_terminal (const char *str, struct grub_term_output *term);

--- a/include/grub/term.h
+++ b/include/grub/term.h
@@ -327,6 +327,7 @@ grub_term_unregister_output (grub_term_output_t term)
 void grub_putcode (grub_uint32_t code, struct grub_term_output *term);
 int EXPORT_FUNC(grub_getkey) (void);
 int EXPORT_FUNC(grub_getkey_noblock) (void);
+int EXPORT_FUNC(grub_getkeystatus) (void);
 void grub_cls (void);
 void EXPORT_FUNC(grub_refresh) (void);
 void grub_puts_terminal (const char *str, struct grub_term_output *term);

--- a/util/grub-editenv.c
+++ b/util/grub-editenv.c
@@ -53,6 +53,9 @@ static struct argp_option options[] = {
   /* TRANSLATORS: "unset" is a keyword. It's a summary of "unset" subcommand.  */
   {N_("unset [NAME ...]"),    0, 0, OPTION_DOC|OPTION_NO_USAGE,
    N_("Delete variables."), 0},
+  /* TRANSLATORS: "incr" is a keyword. It's a summary of "incr" subcommand.  */
+  {N_("incr [NAME ...]"),     0, 0, OPTION_DOC|OPTION_NO_USAGE,
+   N_("Increase value of integer variables."), 0},
 
   {0,         0, 0, OPTION_DOC, N_("Options:"), -1},
   {"verbose", 'v', 0, 0, N_("print verbose messages."), 0},
@@ -246,6 +249,51 @@ unset_variables (const char *name, int argc, char *argv[])
   grub_envblk_close (envblk);
 }
 
+struct get_int_value_params {
+  char *varname;
+  int value;
+};
+
+static int
+get_int_value (const char *varname, const char *value, void *hook_data)
+{
+  struct get_int_value_params *params = hook_data;
+
+  if (strcmp (varname, params->varname) == 0) {
+    params->value = strtol (value, NULL, 10);
+    return 1;
+  }
+  return 0;
+}
+
+static void
+incr_variables (const char *name, int argc, char *argv[])
+{
+  grub_envblk_t envblk;
+  char buf[16];
+
+  envblk = open_envblk_file (name);
+  while (argc)
+    {
+      struct get_int_value_params params = {
+        .varname = argv[0],
+        .value = 0, /* Consider unset variables 0 */
+      };
+
+      grub_envblk_iterate (envblk, &params, get_int_value);
+      snprintf(buf, sizeof(buf), "%d", params.value + 1);
+
+      if (! grub_envblk_set (envblk, argv[0], buf))
+        grub_util_error ("%s", _("environment block too small"));
+
+      argc--;
+      argv++;
+    }
+
+  write_envblk (name, envblk);
+  grub_envblk_close (envblk);
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -285,6 +333,8 @@ main (int argc, char *argv[])
     set_variables (filename, argc - curindex, argv + curindex);
   else if (strcmp (command, "unset") == 0)
     unset_variables (filename, argc - curindex, argv + curindex);
+  else if (strcmp (command, "incr") == 0)
+    incr_variables (filename, argc - curindex, argv + curindex);
   else
     {
       char *program = xstrdup(program_name);

--- a/util/grub-set-bootflag.1
+++ b/util/grub-set-bootflag.1
@@ -1,0 +1,20 @@
+.TH GRUB-SET-BOOTFLAG 1 "Tue Jun 12 2018"
+.SH NAME
+\fBgrub-set-bootflag\fR \(em Set a bootflag in the GRUB environment block.
+
+.SH SYNOPSIS
+\fBgrub-set-bootflag\fR <\fIBOOTFLAG\fR>
+
+.SH DESCRIPTION
+\fBgrub-set-bootflag\fR is a command line to set bootflags in GRUB's
+stored environment.
+
+.SH COMMANDS
+.TP
+\fBBOOTFLAG\fR
+.RS 7
+Bootflag to set, one of \fIboot_success\fR or \fIshow_menu_once\fR.
+.RE
+
+.SH SEE ALSO
+.BR "info grub"

--- a/util/grub-set-bootflag.c
+++ b/util/grub-set-bootflag.c
@@ -1,0 +1,158 @@
+/* grub-set-bootflag.c - tool to set boot-flags in the grubenv. */
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2018 Free Software Foundation, Inc.
+ *
+ *  GRUB is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  GRUB is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * NOTE this gets run by users as root (through pkexec), so this does not
+ * use any grub library / util functions to allow for easy auditing.
+ * The grub headers are only included to get certain defines.
+ */
+
+#include <config-util.h>     /* For *_DIR_NAME defines */
+#include <grub/types.h>
+#include <grub/lib/envblk.h> /* For GRUB_ENVBLK_DEFCFG define */
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#define GRUBENV "/" GRUB_BOOT_DIR_NAME "/" GRUB_DIR_NAME "/" GRUB_ENVBLK_DEFCFG
+#define GRUBENV_SIZE 1024
+
+const char *bootflags[] = {
+  "boot_success",
+  "menu_show_once",
+  NULL
+};
+
+static void usage(void)
+{
+  int i;
+
+  fprintf (stderr, "Usage: 'grub-set-bootflag <bootflag>', where <bootflag> is one of:\n");
+  for (i = 0; bootflags[i]; i++)
+    fprintf (stderr, "  %s\n", bootflags[i]);
+}
+
+int main(int argc, char *argv[])
+{
+  /* NOTE buf must be at least the longest bootflag length + 4 bytes */
+  char env[GRUBENV_SIZE + 1], buf[64], *s;
+  const char *bootflag;
+  int i, len, ret;
+  FILE *f;
+
+  if (argc != 2)
+    {
+      usage();
+      return 1;
+    }
+
+  for (i = 0; bootflags[i]; i++)
+    if (!strcmp (argv[1], bootflags[i]))
+      break;
+  if (!bootflags[i])
+    {
+      fprintf (stderr, "Invalid bootflag: '%s'\n", argv[1]);
+      usage();
+      return 1;
+    }
+
+  bootflag = bootflags[i];
+  len = strlen (bootflag);
+
+  f = fopen (GRUBENV, "r");
+  if (!f)
+    {
+      perror ("Error opening " GRUBENV " for reading");
+      return 1;     
+    }
+
+  ret = fread (env, 1, GRUBENV_SIZE, f);
+  fclose (f);
+  if (ret != GRUBENV_SIZE)
+    {
+      perror ("Error reading from " GRUBENV);
+      return 1;     
+    }
+
+  /* 0 terminate env */
+  env[GRUBENV_SIZE] = 0;
+
+  if (strncmp (env, GRUB_ENVBLK_SIGNATURE, strlen (GRUB_ENVBLK_SIGNATURE)))
+    {
+      fprintf (stderr, "Error invalid environment block\n");
+      return 1;
+    }
+
+  /* Find a pre-existing definition of the bootflag */
+  s = strstr (env, bootflag);
+  while (s && s[len] != '=')
+    s = strstr (s + len, bootflag);
+
+  if (s && ((s[len + 1] != '0' && s[len + 1] != '1') || s[len + 2] != '\n'))
+    {
+      fprintf (stderr, "Pre-existing bootflag '%s' has unexpected value\n", bootflag);
+      return 1;     
+    }
+
+  /* No pre-existing bootflag? -> find free space */
+  if (!s)
+    {
+      for (i = 0; i < (len + 3); i++)
+        buf[i] = '#';
+      buf[i] = 0;
+      s = strstr (env, buf);
+    }
+
+  if (!s)
+    {
+      fprintf (stderr, "No space in grubenv to store bootflag '%s'\n", bootflag);
+      return 1;     
+    }
+
+  /* The grubenv is not 0 terminated, so memcpy the name + '=' , '1', '\n' */
+  snprintf(buf, sizeof(buf), "%s=1\n", bootflag);
+  memcpy(s, buf, len + 3);
+
+  /* "r+", don't truncate so that the diskspace stays reserved */
+  f = fopen (GRUBENV, "r+");
+  if (!f)
+    {
+      perror ("Error opening " GRUBENV " for writing");
+      return 1;     
+    }
+
+  ret = fwrite (env, 1, GRUBENV_SIZE, f);
+  if (ret != GRUBENV_SIZE)
+    {
+      perror ("Error writing to " GRUBENV);
+      return 1;     
+    }
+
+  ret = fflush (f);
+  if (ret)
+    {
+      perror ("Error flushing " GRUBENV);
+      return 1;     
+    }
+
+  fsync (fileno (f));
+  fclose (f);
+
+  return 0;
+}

--- a/util/grub.d/00_menu_auto_hide.in
+++ b/util/grub.d/00_menu_auto_hide.in
@@ -1,0 +1,50 @@
+#! /bin/sh
+
+# Disable / skip generating menu-auto-hide config parts on serial terminals
+for x in ${GRUB_TERMINAL_INPUT} ${GRUB_TERMINAL_OUTPUT}; do
+  case "$x" in
+    serial*)
+      exit 0
+      ;;
+  esac
+done
+
+cat << EOF
+if [ "\${boot_success}" = "1" -o "\${boot_indeterminate}" = "1" ]; then
+  set last_boot_ok=1
+else
+  set last_boot_ok=0
+fi
+
+# Reset boot_indeterminate after a successful boot
+if [ "\${boot_success}" = "1" ] ; then
+  set boot_indeterminate=0
+  save_env boot_indeterminate
+# Avoid boot_indeterminate causing the menu to be hidden more then once
+elif [ "\${boot_indeterminate}" = "1" ]; then
+  set boot_indeterminate=2
+  save_env boot_indeterminate
+fi
+set boot_success=0
+save_env boot_success
+
+if [ x\$feature_timeout_style = xy ] ; then
+  if [ "\${menu_show_once}" ]; then
+    unset menu_show_once
+    save_env menu_show_once
+    set timeout_style=menu
+    unset timeout
+  elif [ "\${menu_auto_hide}" -a "\${last_boot_ok}" = "1" ]; then
+    set orig_timeout_style=\${timeout_style}
+    set orig_timeout=\${timeout}
+    if [ "\${fastboot}" = "1" ]; then
+      # timeout_style=menu + timeout=0 avoids the countdown code keypress check
+      set timeout_style=menu
+      set timeout=0
+    else
+      set timeout_style=hidden
+      set timeout=1
+    fi
+  fi
+fi
+EOF

--- a/util/grub.d/30_os-prober.in
+++ b/util/grub.d/30_os-prober.in
@@ -42,6 +42,7 @@ if [ -z "${OSPROBED}" ] ; then
 fi
 
 osx_entry() {
+    found_other_os=1
     # TRANSLATORS: it refers on the OS residing on device %s
     onstr="$(gettext_printf "(on %s)" "${DEVICE}")"
     hints=""
@@ -125,6 +126,7 @@ for OS in ${OSPROBED} ; do
 
   case ${BOOT} in
     chain)
+      found_other_os=1
 
 	  onstr="$(gettext_printf "(on %s)" "${DEVICE}")"
       cat << EOF
@@ -155,6 +157,7 @@ EOF
 EOF
     ;;
     efi)
+      found_other_os=1
 
 	EFIPATH=${DEVICE#*@}
 	DEVICE=${DEVICE%@*}
@@ -199,6 +202,7 @@ EOF
 	  LINITRD="${LINITRD#/boot}"
 	fi
 
+        found_other_os=1
 	onstr="$(gettext_printf "(on %s)" "${DEVICE}")"
 	recovery_params="$(echo "${LPARAMS}" | grep single)" || true
 	counter=1
@@ -272,6 +276,7 @@ EOF
       done
     ;;
     hurd)
+      found_other_os=1
       onstr="$(gettext_printf "(on %s)" "${DEVICE}")"
       cat << EOF
 menuentry '$(echo "${LONGNAME} $onstr" | grub_quote)' --class hurd --class gnu --class os \$menuentry_id_option 'osprober-gnuhurd-/boot/gnumach.gz-false-$(grub_get_device_id "${DEVICE}")' {
@@ -298,6 +303,7 @@ EOF
 EOF
     ;;
     minix)
+      found_other_os=1
 	  cat << EOF
 menuentry "${LONGNAME} (on ${DEVICE}, Multiboot)" {
 EOF
@@ -329,3 +335,15 @@ EOF
       esac
   esac
 done
+
+# We override the results of the menu_auto_hide code here, this is a bit ugly,
+# but grub-mkconfig writes out the file linearly, so this is the only way
+if [ "${found_other_os}" = "1" ]; then
+  cat << EOF
+# Other OS found, undo autohiding of menu unless menu_auto_hide=2
+if [ "\${orig_timeout_style}" -a "\${menu_auto_hide}" != "2" ]; then
+  set timeout_style=\${orig_timeout_style}
+  set timeout=\${orig_timeout}
+fi
+EOF
+fi

--- a/util/grub.d/30_uefi-firmware.in
+++ b/util/grub.d/30_uefi-firmware.in
@@ -1,0 +1,46 @@
+#! /bin/sh
+set -e
+
+# grub-mkconfig helper script.
+# Copyright (C) 2012  Free Software Foundation, Inc.
+#
+# GRUB is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GRUB is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+
+prefix="@prefix@"
+exec_prefix="@exec_prefix@"
+datarootdir="@datarootdir@"
+
+export TEXTDOMAIN=@PACKAGE@
+export TEXTDOMAINDIR="@localedir@"
+
+. "@datadir@/@PACKAGE@/grub-mkconfig_lib"
+
+efi_vars_dir=/sys/firmware/efi/vars
+EFI_GLOBAL_VARIABLE=8be4df61-93ca-11d2-aa0d-00e098032b8c
+OsIndications="$efi_vars_dir/OsIndicationsSupported-$EFI_GLOBAL_VARIABLE/data"
+
+if [ -e "$OsIndications" ] && \
+   [ "$(( $(printf 0x%x \'"$(cat $OsIndications | cut -b1)") & 1 ))" = 1 ]; then
+  LABEL="System setup"
+
+  gettext_printf "Adding boot menu entry for EFI firmware configuration\n" >&2
+
+  onstr="$(gettext_printf "(on %s)" "${DEVICE}")"
+
+  cat << EOF
+menuentry '$LABEL' \$menuentry_id_option 'uefi-firmware' {
+	fwsetup
+}
+EOF
+fi


### PR DESCRIPTION
Hi Peter, Javier,

Here is a series of grub patches for the boot experience improvements I've been working on.

The first patch is one you already know, which stops grub from needlessly switching the EFI display to text mode when there is no output. This version fixes a few small compiler warnings (I removed a bunch of __unused attributes which should stay) and is otherwise unmodified

Patches 2-4 add getkeystatus() support to the EFI console driver and furhter preparation work for patch 5, which adds F8 and keeping shift pressed as extra methods to unhide the menu

Patch 6 modifies the grub-editenv util so that it can increment integer value grubenv variables, we need this for the boot_indeterminate count, the plan is e.g. to add a "grub2-editenv - incr boot_indeterminate" call to /usr/libexec/selinux/selinux-autorelabel

Patch 7 adds a new file dropping into grub.d adding the menu auto-hide stuff to grub.cfg. I put this in a separate file for easier rebasing on top of newer upstream grub versions

Patch 8 is taken 1:1 from Ubuntu, it adds a "System setup" menu entry to enter the EFI firmware setup, which is useful when using fastboot. Note patch 7 also allows doing this by setting "fwsetup_once=1" in the grunenv, but I believe it is good to have multiple ways to do this for systems where the firmware itself does not check for keypresses.

Please review and cherry-pick the ones which you think are ready for merging. Then I will rebase and address comments on the other patches.

Regards,

Hans