### PR TITLE
docs: Add grub-boot-indeterminate.service example

### DIFF
--- a/docs/grub-boot-indeterminate.service
+++ b/docs/grub-boot-indeterminate.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Mark boot as indeterminate
+DefaultDependencies=false
+Requires=sysinit.target
+After=sysinit.target
+Wants=system-update-pre.target
+Before=system-update-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/grub2-editenv - incr boot_indeterminate


### PR DESCRIPTION
This is an example service file, for use from e.g.
/lib/systemd/system/system-update-pre.target.wants
to increment the boot_indeterminate variable when doing
offline updates.

Signed-off-by: Hans de Goede <hdegoede@redhat.com>