### PR TITLE
00_menu_auto_hide: Use a timeout of 60s for menu_show_once, rather th…

### DIFF
--- a/util/grub.d/00_menu_auto_hide.in
+++ b/util/grub.d/00_menu_auto_hide.in
@@ -33,7 +33,7 @@ if [ x\$feature_timeout_style = xy ] ; then
     unset menu_show_once
     save_env menu_show_once
     set timeout_style=menu
-    unset timeout
+    set timeout=60
   elif [ "\${menu_auto_hide}" -a "\${last_boot_ok}" = "1" ]; then
     set orig_timeout_style=\${timeout_style}
     set orig_timeout=\${timeout}


### PR DESCRIPTION
…en no timeout

On some UEFI systems with fastboot enabled (USB) keyboards don't work at
all, not even when explictly asking for keyboard input.

So lets change the timeout from not set (no timeout) to 60 seconds, so
that on such systems if the menu was requested we continue with the
default choice after 60 seconds.

Signed-off-by: Hans de Goede <hdegoede@redhat.com>