### PR TITLE
00_menu_auto_hide: Reduce number of save_env calls

### DIFF
--- a/util/grub.d/00_menu_auto_hide.in
+++ b/util/grub.d/00_menu_auto_hide.in
@@ -19,14 +19,12 @@ fi
 # Reset boot_indeterminate after a successful boot
 if [ "\${boot_success}" = "1" ] ; then
   set boot_indeterminate=0
-  save_env boot_indeterminate
 # Avoid boot_indeterminate causing the menu to be hidden more then once
 elif [ "\${boot_indeterminate}" = "1" ]; then
   set boot_indeterminate=2
-  save_env boot_indeterminate
 fi
 set boot_success=0
-save_env boot_success
+save_env boot_success boot_indeterminate
 
 if [ x\$feature_timeout_style = xy ] ; then
   if [ "\${menu_show_once}" ]; then


### PR DESCRIPTION
Normally boot_success will be 1 on every boot (as normally the
previous boot will have been successful). This means that we end
up in the code-path to set boot_indeterminate to 0 every boot.

So we do 2 separate save_env calls each boot, one for boot_indeterminate
and one for boot_success. This results in 2 writes to the disk.

This commit makes us save both boot_success and boot_indeterminate
in a single call, reducing the number of writes, thus reducing wear
and tear on the underlying storage.

Signed-off-by: Hans de Goede <hdegoede@redhat.com>