### PR TITLE
Fix "Try to pick better locations for kernel and initrd" causing boot to fail on some UEFI x86_64 systems

### DIFF
--- a/grub-core/loader/i386/efi/linux.c
+++ b/grub-core/loader/i386/efi/linux.c
@@ -110,6 +110,10 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
     }
 
   initrd_mem = grub_efi_allocate_pages_max (GRUB_EFI_MAX_USABLE_ADDRESS, BYTES_TO_PAGES(size));
+
+  if (!initrd_mem)
+    initrd_mem = grub_efi_allocate_pages_max (0x3fffffff, BYTES_TO_PAGES(size));
+
   if (!initrd_mem)
     {
       grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("can't allocate initrd"));
@@ -212,6 +216,11 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 
   params = grub_efi_allocate_pages_max (GRUB_EFI_MAX_USABLE_ADDRESS,
 					BYTES_TO_PAGES(sizeof(*params)));
+
+  if (! params)
+    params = grub_efi_allocate_pages_max (0x3fffffff,
+					  BYTES_TO_PAGES(sizeof(*params)));
+
   if (! params)
     {
       grub_error (GRUB_ERR_OUT_OF_MEMORY, "cannot allocate kernel parameters");
@@ -311,6 +320,10 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 
   if (!kernel_mem)
     kernel_mem = grub_efi_allocate_pages_max(GRUB_EFI_MAX_USABLE_ADDRESS,
+					     BYTES_TO_PAGES(lh->init_size));
+
+  if (!kernel_mem)
+    kernel_mem = grub_efi_allocate_pages_max(0x3fffffff,
 					     BYTES_TO_PAGES(lh->init_size));
 
   if (!kernel_mem)


### PR DESCRIPTION
The "Try to pick better locations for kernel and initrd" commit causes boot
to fail on some UEFI x86_64 systems (Sandy Bridge) with these errors:

grub-core/loader/i386/efi/linux.c:217:cannot allocate kernel parameters.
grub-core/loader/i386/efi/linux.c:94:you need to load the kernel first.

This commit fixes this by retrying the memory allocations changed by
the "Try to pick better locations for kernel and initrd" commit with
the old memory limit of 0x3fffffff.

BugLink: https://bugzilla.redhat.com/show_bug.cgi?id=1624525
Signed-off-by: Hans de Goede <hdegoede@redhat.com>