### PR TITLE
grub-boot-success.timer: Add a few Conditions for running the timer

### DIFF
--- a/docs/grub-boot-success.timer
+++ b/docs/grub-boot-success.timer
@@ -1,5 +1,7 @@
 [Unit]
 Description=Mark boot as successful after the user session has run 2 minutes
+ConditionUser=!@system
+ConditionPathExists=/usr/bin/pkexec
 
 [Timer]
 OnActiveSec=2min

--- a/grub-core/commands/blscfg.c
+++ b/grub-core/commands/blscfg.c
@@ -434,7 +434,7 @@ finish:
 
 static grub_envblk_t saved_env = NULL;
 
-static int
+static int UNUSED
 save_var (const char *name, const char *value, void *whitelist UNUSED)
 {
   const char *val = grub_env_get (name);
@@ -446,7 +446,7 @@ save_var (const char *name, const char *value, void *whitelist UNUSED)
   return 0;
 }
 
-static int
+static int UNUSED
 unset_var (const char *name, const char *value UNUSED, void *whitelist)
 {
   grub_dprintf("blscfg", "restoring \"%s\"\n", name);

--- a/grub-core/kern/efi/mm.c
+++ b/grub-core/kern/efi/mm.c
@@ -157,12 +157,20 @@ grub_efi_allocate_pages_real (grub_efi_physical_address_t address,
 
   /* Limit the memory access to less than 4GB for 32-bit platforms.  */
   if (address > GRUB_EFI_MAX_USABLE_ADDRESS)
-    return 0;
+    {
+      grub_error (GRUB_ERR_BAD_ARGUMENT,
+		  N_("invalid memory address (0x%llx > 0x%llx)"),
+		  address, GRUB_EFI_MAX_USABLE_ADDRESS);
+      return NULL;
+    }
 
   b = grub_efi_system_table->boot_services;
   status = efi_call_4 (b->allocate_pages, alloctype, memtype, pages, &address);
   if (status != GRUB_EFI_SUCCESS)
-    return 0;
+    {
+      grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("out of memory"));
+      return NULL;
+    }
 
   if (address == 0)
     {
@@ -172,7 +180,10 @@ grub_efi_allocate_pages_real (grub_efi_physical_address_t address,
       status = efi_call_4 (b->allocate_pages, alloctype, memtype, pages, &address);
       grub_efi_free_pages (0, pages);
       if (status != GRUB_EFI_SUCCESS)
-	return 0;
+	{
+	  grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("out of memory"));
+	  return NULL;
+	}
     }
 
   grub_efi_store_alloc (address, pages);

--- a/grub-core/kern/efi/mm.c
+++ b/grub-core/kern/efi/mm.c
@@ -122,7 +122,7 @@ grub_efi_allocate_pages_max (grub_efi_physical_address_t max,
   grub_efi_boot_services_t *b;
   grub_efi_physical_address_t address = max;
 
-  if (max > 0xffffffff)
+  if (max >= GRUB_EFI_MAX_USABLE_ADDRESS)
     return 0;
 
   b = grub_efi_system_table->boot_services;

--- a/grub-core/kern/err.c
+++ b/grub-core/kern/err.c
@@ -33,15 +33,24 @@ static struct grub_error_saved grub_error_stack_items[GRUB_ERROR_STACK_SIZE];
 static int grub_error_stack_pos;
 static int grub_error_stack_assert;
 
+#ifdef grub_error
+#undef grub_error
+#endif
+
 grub_err_t
-grub_error (grub_err_t n, const char *fmt, ...)
+grub_error (grub_err_t n, const char *file, const int line, const char *fmt, ...)
 {
   va_list ap;
+  int m;
 
   grub_errno = n;
 
+  m = grub_snprintf (grub_errmsg, sizeof (grub_errmsg), "%s:%d:", file, line);
+  if (m < 0)
+    m = 0;
+
   va_start (ap, fmt);
-  grub_vsnprintf (grub_errmsg, sizeof (grub_errmsg), _(fmt), ap);
+  grub_vsnprintf (grub_errmsg + m, sizeof (grub_errmsg) - m, _(fmt), ap);
   va_end (ap);
 
   return n;

--- a/grub-core/kern/main.c
+++ b/grub-core/kern/main.c
@@ -131,7 +131,7 @@ grub_set_prefix_and_root (void)
     {
       char *fw_path;
 
-      fw_path = grub_xasprintf ("(%s)/%s", fwdevice, fwpath);
+      fw_path = grub_xasprintf ("(%s)%s%s", fwdevice, fwpath[0] == '/' ? "" : "/", fwpath);
       if (fw_path)
 	{
 	  grub_env_set ("fw_path", fw_path);

--- a/grub-core/loader/efi/linux.c
+++ b/grub-core/loader/efi/linux.c
@@ -79,7 +79,10 @@ grub_efi_linux_boot (void *kernel_addr, grub_off_t handover_offset,
   offset = 512;
 #endif
 
+  grub_dprintf ("linux", "kernel_addr: %p handover_offset: %p params: %p\n",
+		kernel_addr, (void *)(grub_efi_uintn_t)handover_offset, kernel_params);
   hf = (handover_func)((char *)kernel_addr + handover_offset + offset);
+  grub_dprintf ("linux", "handover_func() = %p\n", hf);
   hf (grub_efi_image_handle, grub_efi_system_table, kernel_params);
 
   return GRUB_ERR_BUG;

--- a/grub-core/loader/i386/efi/linux.c
+++ b/grub-core/loader/i386/efi/linux.c
@@ -28,6 +28,7 @@
 #include <grub/efi/efi.h>
 #include <grub/efi/linux.h>
 #include <grub/tpm.h>
+#include <grub/cpu/efi/memory.h>
 
 GRUB_MOD_LICENSE ("GPLv3+");
 
@@ -108,7 +109,7 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
       size += ALIGN_UP (grub_file_size (files[i]), 4);
     }
 
-  initrd_mem = grub_efi_allocate_pages_max (0x3fffffff, BYTES_TO_PAGES(size));
+  initrd_mem = grub_efi_allocate_pages_max (GRUB_EFI_MAX_USABLE_ADDRESS, BYTES_TO_PAGES(size));
   if (!initrd_mem)
     {
       grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("can't allocate initrd"));
@@ -209,7 +210,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
       goto fail;
     }
 
-  params = grub_efi_allocate_pages_max (0x3fffffff,
+  params = grub_efi_allocate_pages_max (GRUB_EFI_MAX_USABLE_ADDRESS,
 					BYTES_TO_PAGES(sizeof(*params)));
   if (! params)
     {
@@ -309,7 +310,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 					   BYTES_TO_PAGES(lh->init_size));
 
   if (!kernel_mem)
-    kernel_mem = grub_efi_allocate_pages_max(0x3fffffff,
+    kernel_mem = grub_efi_allocate_pages_max(GRUB_EFI_MAX_USABLE_ADDRESS,
 					     BYTES_TO_PAGES(lh->init_size));
 
   if (!kernel_mem)

--- a/grub-core/net/efi/http.c
+++ b/grub-core/net/efi/http.c
@@ -9,10 +9,52 @@
 static void
 http_configure (struct grub_efi_net_device *dev, int prefer_ip6)
 {
+  grub_efi_ipv6_address_t address;
   grub_efi_http_config_data_t http_config;
   grub_efi_httpv4_access_point_t httpv4_node;
   grub_efi_httpv6_access_point_t httpv6_node;
   grub_efi_status_t status;
+  int https;
+  char *http_url;
+  const char *rest, *http_server, *http_path = NULL;
+
+  http_server = grub_env_get ("root");
+  https = grub_strncmp (http_server, "https", 5) ? 1 : 0;
+
+  /* extract http server + port */
+  if (http_server)
+    {
+      http_server = grub_strchr (http_server, ',');
+      if (http_server)
+	http_server++;
+    }
+
+  /* fw_path is like (http,192.168.1.1:8000)/httpboot, extract path part */
+  http_path = grub_env_get ("fw_path");
+  if (http_path)
+    {
+      http_path = grub_strchr (http_path, ')');
+      if (http_path)
+	{
+	  http_path++;
+	  grub_env_unset ("http_path");
+	  grub_env_set ("http_path", http_path);
+	}
+    }
+
+  if (http_server && http_path)
+    {
+      if (grub_efi_string_to_ip6_address (http_server, &address, &rest) && *rest == 0)
+	http_url = grub_xasprintf ("%s://[%s]%s", https ? "https" : "http", http_server, http_path);
+      else
+	http_url = grub_xasprintf ("%s://%s%s", https ? "https" : "http", http_server, http_path);
+      if (http_url)
+	{
+	  grub_env_unset ("http_url");
+	  grub_env_set ("http_url", http_url);
+	  grub_free (http_url);
+	}
+    }
 
   grub_efi_http_t *http = dev->http;
 
@@ -352,32 +394,32 @@ grub_efihttp_open (struct grub_efi_net_device *dev,
   grub_err_t err;
   grub_off_t size;
   char *buf;
-  char *root_url;
-  grub_efi_ipv6_address_t address;
-  const char *rest;
+  char *file_name;
+  const char *http_path;
 
-  if (grub_efi_string_to_ip6_address (file->device->net->server, &address, &rest) && *rest == 0)
-    root_url = grub_xasprintf ("%s://[%s]", type ? "https" : "http", file->device->net->server);
+  /* If path is relative, prepend http_path */
+  http_path = grub_env_get ("http_path");
+  if (http_path && file->device->net->name[0] != '/')
+    file_name = grub_xasprintf ("%s/%s", http_path, file->device->net->name);
   else
-    root_url = grub_xasprintf ("%s://%s", type ? "https" : "http", file->device->net->server);
-  if (root_url)
+    file_name = grub_strdup (file->device->net->name);
+
+  if (!file_name)
+    return grub_errno;
+
+  err = efihttp_request (dev->http, file->device->net->server, file_name, type, 1, 0);
+  if (err != GRUB_ERR_NONE)
     {
-      grub_env_unset ("root_url");
-      grub_env_set ("root_url", root_url);
-      grub_free (root_url);
-    }
-  else
-    {
-      return grub_errno;
+      grub_free (file_name);
+      return err;
     }
 
-  err = efihttp_request (dev->http, file->device->net->server, file->device->net->name, type, 1, 0);
+  err = efihttp_request (dev->http, file->device->net->server, file_name, type, 0, &size);
+  grub_free (file_name);
   if (err != GRUB_ERR_NONE)
-    return err;
-
-  err = efihttp_request (dev->http, file->device->net->server, file->device->net->name, type, 0, &size);
-  if (err != GRUB_ERR_NONE)
-    return err;
+    {
+      return err;
+    }
 
   buf = grub_malloc (size);
   efihttp_read (dev, buf, size);

--- a/include/grub/arm/linux.h
+++ b/include/grub/arm/linux.h
@@ -31,7 +31,7 @@ struct linux_arm_kernel_header {
   grub_uint32_t magic;
   grub_uint32_t start; /* _start */
   grub_uint32_t end;   /* _edata */
-  grub_uint32_t reserved2[4];
+  grub_uint32_t reserved2[3];
   grub_uint32_t hdr_offset;
 };
 

--- a/include/grub/arm64/efi/memory.h
+++ b/include/grub/arm64/efi/memory.h
@@ -1,6 +1,6 @@
 #ifndef GRUB_MEMORY_CPU_HEADER
 #include <grub/efi/memory.h>
 
-#define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffffffffULL
+#define GRUB_EFI_MAX_USABLE_ADDRESS __UINTPTR_MAX__
 
 #endif /* ! GRUB_MEMORY_CPU_HEADER */

--- a/include/grub/err.h
+++ b/include/grub/err.h
@@ -84,7 +84,10 @@ struct grub_error_saved
 extern grub_err_t EXPORT_VAR(grub_errno);
 extern char EXPORT_VAR(grub_errmsg)[GRUB_MAX_ERRMSG];
 
-grub_err_t EXPORT_FUNC(grub_error) (grub_err_t n, const char *fmt, ...);
+grub_err_t EXPORT_FUNC(grub_error) (grub_err_t n, const char *file, const int line, const char *fmt, ...);
+
+#define grub_error(n, fmt, ...) grub_error (n, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+
 void EXPORT_FUNC(grub_fatal) (const char *fmt, ...) __attribute__ ((noreturn));
 void EXPORT_FUNC(grub_error_push) (void);
 int EXPORT_FUNC(grub_error_pop) (void);

--- a/include/grub/x86_64/efi/memory.h
+++ b/include/grub/x86_64/efi/memory.h
@@ -2,9 +2,9 @@
 #include <grub/efi/memory.h>
 
 #if defined (__code_model_large__)
-#define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffffffffffffULL
+#define GRUB_EFI_MAX_USABLE_ADDRESS __UINTPTR_MAX__
 #else
-#define GRUB_EFI_MAX_USABLE_ADDRESS 0x7fffffffffffffffULL
+#define GRUB_EFI_MAX_USABLE_ADDRESS __INTPTR_MAX__
 #endif
 
 #endif /* ! GRUB_MEMORY_CPU_HEADER */

--- a/include/grub/x86_64/efi/memory.h
+++ b/include/grub/x86_64/efi/memory.h
@@ -2,9 +2,9 @@
 #include <grub/efi/memory.h>
 
 #if defined (__code_model_large__)
-#define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffff
+#define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffffffffffffULL
 #else
-#define GRUB_EFI_MAX_USABLE_ADDRESS 0x7fffffff
+#define GRUB_EFI_MAX_USABLE_ADDRESS 0x7fffffffffffffffULL
 #endif
 
 #endif /* ! GRUB_MEMORY_CPU_HEADER */


### PR DESCRIPTION
Add 2 Conditions for running the boot-success timer / service:

1) Do not run it for system users, this fixes errors about gdm not being
allowed to use pkexec when the greeter session lasts for more then 2 minutes:
https://bugzilla.redhat.com/show_bug.cgi?id=1592201#c6

2) Do not run the timer when pkexec is not available (on minimal installs)
since then it will just lead to a bunch of errors without doing anything:
https://bugzilla.redhat.com/show_bug.cgi?id=1619445

Signed-off-by: Hans de Goede <hdegoede@redhat.com>