### PR TITLE
Move quicksort function from kernel.exec to the blscfg module

### DIFF
--- a/grub-core/Makefile.core.def
+++ b/grub-core/Makefile.core.def
@@ -129,7 +129,6 @@ kernel = {
   common = kern/rescue_parser.c;
   common = kern/rescue_reader.c;
   common = kern/term.c;
-  common = kern/qsort.c;
   common = kern/backtrace.c;
   common = kern/tpm.c;
 
@@ -787,6 +786,7 @@ module = {
 module = {
   name = blscfg;
   common = commands/blscfg.c;
+  common = commands/bls_qsort.h;
   common = commands/loadenv.h;
   enable = efi;
   enable = i386_pc;

--- a/grub-core/Makefile.core.def
+++ b/grub-core/Makefile.core.def
@@ -788,6 +788,7 @@ module = {
   common = commands/blscfg.c;
   common = commands/bls_qsort.h;
   common = commands/loadenv.h;
+  enable = powerpc_ieee1275;
   enable = efi;
   enable = i386_pc;
   enable = emu;

--- a/grub-core/commands/bls_qsort.h
+++ b/grub-core/commands/bls_qsort.h
@@ -64,6 +64,7 @@ typedef struct
 #define	POP(low, high)	((void) (--top, (low = top->lo), (high = top->hi)))
 #define	STACK_NOT_EMPTY	(stack < top)
 
+typedef int (*grub_compar_d_fn_t) (const void *p0, const void *p1, void *state);
 
 /* Order size using quicksort.  This implementation incorporates
    four optimizations discussed in Sedgewick:
@@ -90,7 +91,7 @@ typedef struct
       stack size is needed (actually O(1) in this case)!  */
 
 void
-grub_qsort (void *const pbase, grub_size_t total_elems, grub_size_t size,
+bls_qsort (void *const pbase, grub_size_t total_elems, grub_size_t size,
 	    grub_compar_d_fn_t cmp, void *arg)
 {
   char *base_ptr = (char *) pbase;
@@ -252,28 +253,3 @@ grub_qsort (void *const pbase, grub_size_t total_elems, grub_size_t size,
   }
 }
 
-void *
-grub_bsearch (const void *key, const void *base, grub_size_t nmemb, grub_size_t size,
-	 grub_compar_d_fn_t compar, void *state)
-{
-  grub_size_t l, u, idx;
-  const void *p;
-  int comparison;
-
-  l = 0;
-  u = nmemb;
-  while (l < u)
-    {
-      idx = (l + u) / 2;
-      p = (void *) (((const char *) base) + (idx * size));
-      comparison = (*compar) (key, p, state);
-      if (comparison < 0)
-	u = idx;
-      else if (comparison > 0)
-	l = idx + 1;
-      else
-	return (void *) p;
-    }
-
-  return NULL;
-}

--- a/grub-core/commands/blscfg.c
+++ b/grub-core/commands/blscfg.c
@@ -36,6 +36,7 @@
 
 GRUB_MOD_LICENSE ("GPLv3+");
 
+#include "bls_qsort.h"
 #include "loadenv.h"
 
 #define GRUB_BLS_CONFIG_PATH "/loader/entries/"
@@ -717,7 +718,7 @@ read_fallback:
       use_version = false;
   }
 
-  grub_qsort(&entries[0], nentries, sizeof (struct bls_entry *), bls_cmp, &use_version);
+  bls_qsort(&entries[0], nentries, sizeof (struct bls_entry *), bls_cmp, &use_version);
 
   grub_dprintf ("blscfg", "%s Creating %d entries from bls\n", __func__, nentries);
   for (r = nentries - 1; r >= 0; r--)

--- a/include/grub/misc.h
+++ b/include/grub/misc.h
@@ -510,19 +510,4 @@ void EXPORT_FUNC(grub_real_boot_time) (const char *file,
 #define grub_max(a, b) (((a) > (b)) ? (a) : (b))
 #define grub_min(a, b) (((a) < (b)) ? (a) : (b))
 
-typedef int (*grub_compar_d_fn_t) (const void *p0, const void *p1, void *state);
-
-void *EXPORT_FUNC(grub_bsearch) (const void *key,
-			    const void *base,
-			    grub_size_t nmemb,
-			    grub_size_t size,
-			    grub_compar_d_fn_t compar,
-			    void *state);
-
-void EXPORT_FUNC(grub_qsort) (void *const pbase,
-			 grub_size_t total_elems,
-			 grub_size_t size,
-			 grub_compar_d_fn_t cmp,
-			 void *state);
-
 #endif /* ! GRUB_MISC_HEADER */

--- a/util/grub-switch-to-blscfg.in
+++ b/util/grub-switch-to-blscfg.in
@@ -53,6 +53,8 @@ blsdir=`echo "/@bootdirname@/loader/entries" | sed 's,//*,/,g'`
 
 backupsuffix=.bak
 
+arch="$(uname -m)"
+
 export TEXTDOMAIN=@PACKAGE@
 export TEXTDOMAINDIR="@localedir@"
 
@@ -248,7 +250,6 @@ for kernelver in $(cd /lib/modules/ ; ls -1) "" ; do
     fi
 
     if [ "x$GRUB_LINUX_MAKE_DEBUG" = "xtrue" ]; then
-        arch="$(uname -m)"
         bls_debug="$(echo ${bls_target} | sed -e "s/\.${arch}/-debug.${arch}/")"
         cp -aT  "${bls_target}" "${bls_debug}"
         title="$(grep '^title[ \t]' "${bls_debug}" | sed -e 's/^title[ \t]*//')"
@@ -282,6 +283,16 @@ elif ! grep -q '^GRUB_ENABLE_BLSCFG=.*' "${etcdefaultgrub}" ; then
 fi
 
 if [ "${GENERATE}" -eq 1 ] ; then
+    if [ $arch = "x86_64" ] && [ ! -d /sys/firmware/efi ]; then
+	if ! cp ${prefix}/lib/grub//i386-pc/blscfg.mod ${grubdir}/i386-pc/ ; then
+	    exit 1
+	fi
+    elif [ $arch = "ppc64" -o $arch = "ppc64le" ] && [ ! -d /sys/firmware/opal ]; then
+	if ! cp ${prefix}/lib/grub/powerpc-ieee1275/blscfg.mod ${grubdir}/powerpc-ieee1275/ ; then
+	    exit 1
+	fi
+    fi
+
     cp -af "${GRUB_CONFIG_FILE}" "${GRUB_CONFIG_FILE}${backupsuffix}"
     if ! grub2-mkconfig -o "${GRUB_CONFIG_FILE}" ; then
         cp -af "${GRUB_CONFIG_FILE}${backupsuffix}" "${GRUB_CONFIG_FILE}"


### PR DESCRIPTION
The qsort function is defined in the grub2 kernel and exported for modules
to use. But this prevents the blscfg.mod to be loaded by old grub2 kernels
that don't export this symbol.

Loading the latest blscfg module might be useful on legacy BIOS systems to
avoid updating the first and second stage grub2 images in the boot device.

Since the only caller of the qsort function is the blscfg module, move the
qsort function out of the grub2 kernel and only have it in the blscfg.mod.

While being there, also remove the grub_bsearch() function that is unused.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>