### PR TITLE
Add comments and revert logic changes in 01_fallback_counting

### DIFF
--- a/util/grub.d/01_fallback_counting.in
+++ b/util/grub.d/01_fallback_counting.in
@@ -1,15 +1,20 @@
 #! /bin/sh -e
 
 # Boot Counting
+# The boot_counter env var can be used to count down boot attempts after an OSTree upgrade and choose the rollback deployment when 0 is reached.
+# Both boot_counter and boot_success need to be (re-)set from userspace.
 cat << EOF
 insmod increment
-if [ -z "\${boot_counter}" ]; then
-  set boot_counter=0
-elif [ "\${boot_counter}" = "0" -o "\${boot_counter}" = "-1" ]; then
-  increment default
-  set boot_counter=-1
-else
-  decrement boot_counter
+# Check if boot_counter exists and boot_success=0 to activate this behaviour.
+if [ "\${boot_counter}" -a "\${boot_success}" = "0" ]; then
+  # if countdown has ended, choose to boot rollback deployment (default=1 on OSTree-based systems)
+  if  [ "\${boot_counter}" = "0" -o "\${boot_counter}" = "-1" ]; then
+    set default=1
+    set boot_counter=-1
+  # otherwise decrement boot_counter
+  else
+    decrement boot_counter
+  fi
+  save_env boot_counter
 fi
-save_env boot_counter
 EOF


### PR DESCRIPTION
@vathpela sorry for the hassle with this one. Hopefully the comments now sufficiently explain the intended usage.

Edit: see [here](https://github.com/LorbusChris/greenboot/blob/master/tests/run_ostree_upgrade.sh) for an example upgrade script that sets boot_counter and boot_success vars.