### PR TITLE
Fix disabling gnus-rpm-sort

### DIFF
--- a/Makefile.util.def
+++ b/Makefile.util.def
@@ -731,6 +731,7 @@ program = {
   ldadd = grub-core/gnulib/libgnu.a;
   ldadd = libgrubkern.a;
   ldadd = '$(LIBDEVMAPPER) $(LIBRPM)';
+  condition = COND_GRUB_RPM_SORT;
 };
 
 script = {

--- a/configure.ac
+++ b/configure.ac
@@ -2094,6 +2094,7 @@ AM_CONDITIONAL([COND_GRUB_EMU_SDL], [test x$enable_grub_emu_sdl = xyes])
 AM_CONDITIONAL([COND_GRUB_EMU_PCI], [test x$enable_grub_emu_pci = xyes])
 AM_CONDITIONAL([COND_GRUB_MKFONT], [test x$enable_grub_mkfont = xyes])
 AM_CONDITIONAL([COND_GRUB_MOUNT], [test x$enable_grub_mount = xyes])
+AM_CONDITIONAL([COND_GRUB_RPM_SORT], [test x$enable_rpm_sort = xyes])
 AM_CONDITIONAL([COND_HAVE_FONT_SOURCE], [test x$FONT_SOURCE != x])
 if test x$FONT_SOURCE != x ; then
    HAVE_FONT_SOURCE=1
@@ -2214,6 +2215,11 @@ if [ x"$grub_mount_excuse" = x ]; then
 echo grub-mount: Yes
 else
 echo grub-mount: No "($grub_mount_excuse)"
+fi
+if [ x"$rpm_sort_excuse" = x ]; then
+echo grub-rpm-sort: Yes
+else
+echo grub-rpm-sort: No "($rpm_sort_excuse)"
 fi
 if [ x"$starfield_excuse" = x ]; then
 echo starfield theme: Yes


### PR DESCRIPTION
Currently, grub-rpm-sort is unconditionally compiled whether
./configure has been called with --disable-rpm-sort or not.  This adds
the necessary logic to configure.ac and Makefile.util.def and some
debug output to ./configure and fixes #44.

I cannot compile `fedora-29` on my Fedora 28 system (`locale.h` not found), so I have not tested this.