### PR TITLE
Allow chainloading EFI apps from loop mounts

### DIFF
--- a/grub-core/disk/loopback.c
+++ b/grub-core/disk/loopback.c
@@ -21,19 +21,12 @@
 #include <grub/misc.h>
 #include <grub/file.h>
 #include <grub/disk.h>
+#include <grub/loopback.h>
 #include <grub/mm.h>
 #include <grub/extcmd.h>
 #include <grub/i18n.h>
 
 GRUB_MOD_LICENSE ("GPLv3+");
-
-struct grub_loopback
-{
-  char *devname;
-  grub_file_t file;
-  struct grub_loopback *next;
-  unsigned long id;
-};
 
 static struct grub_loopback *loopback_list;
 static unsigned long last_id = 0;

--- a/grub-core/loader/efi/chainloader.c
+++ b/grub-core/loader/efi/chainloader.c
@@ -24,6 +24,7 @@
 #include <grub/err.h>
 #include <grub/device.h>
 #include <grub/disk.h>
+#include <grub/loopback.h>
 #include <grub/misc.h>
 #include <grub/charset.h>
 #include <grub/mm.h>
@@ -879,6 +880,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
   grub_efi_status_t status;
   grub_efi_boot_services_t *b;
   grub_device_t dev = 0;
+  grub_device_t orig_dev = 0;
   grub_efi_device_path_t *dp = 0;
   char *filename;
   void *boot_image = 0;
@@ -935,6 +937,15 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
     grub_free (devname);
   if (! dev)
     goto fail;
+
+  /* if device is loopback, use underlying dev */
+  if (dev->disk->dev->id == GRUB_DISK_DEVICE_LOOPBACK_ID)
+    {
+      struct grub_loopback *d;
+      orig_dev = dev;
+      d = dev->disk->data;
+      dev = d->file->device;
+    }
 
   if (dev->disk)
     dev_handle = grub_efidisk_get_device_handle (dev->disk);
@@ -1043,6 +1054,12 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
     }
 #endif
 
+  if (orig_dev)
+    {
+      dev = orig_dev;
+      orig_dev = 0;
+    }
+
   rc = grub_linuxefi_secure_validate((void *)(unsigned long)address, fsize);
   grub_dprintf ("chain", "linuxefi_secure_validate: %d\n", rc);
   if (rc > 0)
@@ -1064,6 +1081,12 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
     }
 
 fail:
+  if (orig_dev)
+    {
+      dev = orig_dev;
+      orig_dev = 0;
+    }
+
   if (dev)
     grub_device_close (dev);
 

--- a/include/grub/loopback.h
+++ b/include/grub/loopback.h
@@ -1,0 +1,30 @@
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2019  Free Software Foundation, Inc.
+ *
+ *  GRUB is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  GRUB is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef GRUB_LOOPBACK_HEADER
+#define GRUB_LOOPBACK_HEADER	1
+
+struct grub_loopback
+{
+  char *devname;
+  grub_file_t file;
+  struct grub_loopback *next;
+  unsigned long id;
+};
+
+#endif /* ! GRUB_LOOPBACK_HEADER */


### PR DESCRIPTION
I'm trying to switch from booting `linux (loop)/vmlinuz` to BLS Type-2 EFI binaries and thus call `chainloader (loop)/linux.efi` instead

However with SB patches from this repo in-place it fails, due to invalid root device. My understanding is that one needs to resolve the underlying device, that the loopmount is based on, and then set that as the global...

This patch seems to work for me. But currently only tested it unsigned.

One can test this by creating .efi app with e.g. `dracut --uefi` option, and then wrapping the result in a squashfs with `mksquashfs linux.efi linux.squashfs` and then doing `loopback loop /linux.squashfs` followed by `chainloader (loop)/linux.efi` and then `boot`.