### PR TITLE
10_linux.in: restore existence check in `get_sorted_bls`

### DIFF
--- a/util/grub.d/10_linux.in
+++ b/util/grub.d/10_linux.in
@@ -141,6 +141,9 @@ get_sorted_bls()
     local IFS=$'\n'
 
     files=($(for bls in ${blsdir}/*.conf; do
+        if ! [[ -e "${bls}" ]] ; then
+            continue
+        fi
         bls="${bls%.conf}"
         bls="${bls##*/}"
         echo "${bls}"


### PR DESCRIPTION
This is necessary to handle `/boot/loader/entries` not existing
at all (or possibly existing but being empty - not sure about
that case). Without this check, this function gets pretty wacky
and winds up returning the contents of the current working
directory, which of course causes whatever called it to break.

Resolves: rhbz#1836020

Signed-off-by: Adam Williamson <awilliam@redhat.com>