### PR TITLE
Systemd integration: Add support for "systemctl reboot --boot-loader-menu=xx"

### DIFF
--- a/Makefile.util.def
+++ b/Makefile.util.def
@@ -470,6 +470,12 @@ script = {
 };
 
 script = {
+  name = '14_menu_show_once';
+  common = util/grub.d/14_menu_show_once.in;
+  installdir = grubconf;
+};
+
+script = {
   name = '01_users';
   common = util/grub.d/01_users.in;
   installdir = grubconf;
@@ -566,6 +572,27 @@ script = {
   name = '41_custom';
   common = util/grub.d/41_custom.in;
   installdir = grubconf;
+};
+
+script = {
+  name = 'grub-systemd-integration.service';
+  common = util/systemd/grub-systemd-integration.service.in;
+  installdir = systemdunit;
+  condition = COND_HOST_LINUX;
+};
+
+script = {
+  name = 'systemd-integration.sh';
+  common = util/systemd/systemd-integration.sh.in;
+  installdir = grublibexec;
+  condition = COND_HOST_LINUX;
+};
+
+script = {
+  name = '10-grub-logind-service.conf';
+  common = util/systemd/10-grub-logind-service.conf.in;
+  installdir = systemd_logind_service_d;
+  condition = COND_HOST_LINUX;
 };
 
 program = {

--- a/conf/Makefile.common
+++ b/conf/Makefile.common
@@ -63,8 +63,11 @@ CCASFLAGS_LIBRARY = $(UTILS_CCASFLAGS)
 # Other variables
 
 grubconfdir = $(sysconfdir)/grub.d
+grublibexecdir = $(libexecdir)/$(grubdirname)
 platformdir = $(pkglibdir)/$(target_cpu)-$(platform)
 starfielddir = $(pkgdatadir)/themes/starfield
+systemdunitdir = ${prefix}/lib/systemd/system
+systemd_logind_service_ddir = $(systemdunitdir)/systemd-logind.service.d
 
 CFLAGS_GNULIB = -Wno-undef -Wno-unused -Wno-unused-parameter -Wno-redundant-decls -Wno-unreachable-code -Werror=trampolines -fno-trampolines
 CPPFLAGS_GNULIB = -I$(top_builddir)/grub-core/lib/gnulib -I$(top_srcdir)/grub-core/lib/gnulib
@@ -119,6 +122,9 @@ noinst_LIBRARIES =
 dist_noinst_DATA =
 platform_SCRIPTS =
 platform_PROGRAMS =
+grublibexec_SCRIPTS =
+systemdunit_SCRIPTS =
+systemd_logind_service_d_SCRIPTS =
 
 TESTS =
 EXTRA_DIST =

--- a/util/grub.d/14_menu_show_once.in
+++ b/util/grub.d/14_menu_show_once.in
@@ -1,0 +1,13 @@
+#! /bin/sh
+# Force the menu to be shown once, with a timeout of ${menu_show_once_timeout}
+# if requested by ${menu_show_once_timeout} being set in the env.
+cat << EOF
+if [ x\$feature_timeout_style = xy ]; then
+  if [ "\${menu_show_once_timeout}" ]; then
+    set timeout_style=menu
+    set timeout="\${menu_show_once_timeout}"
+    unset menu_show_once_timeout
+    save_env menu_show_once_timeout
+  fi
+fi
+EOF

--- a/util/systemd/10-grub-logind-service.conf.in
+++ b/util/systemd/10-grub-logind-service.conf.in
@@ -1,0 +1,2 @@
+[Service]
+Environment=SYSTEMD_REBOOT_TO_BOOT_LOADER_MENU=true

--- a/util/systemd/grub-systemd-integration.service.in
+++ b/util/systemd/grub-systemd-integration.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Grub2 systemctl reboot --boot-loader-menu=... support
+Before=umount.target systemd-reboot.service
+DefaultDependencies=no
+ConditionPathExists=/run/systemd/reboot-to-boot-loader-menu
+
+[Service]
+ExecStart=@libexecdir@/@grubdirname@/systemd-integration.sh

--- a/util/systemd/systemd-integration.sh.in
+++ b/util/systemd/systemd-integration.sh.in
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+TIMEOUT_USEC=$(cat /run/systemd/reboot-to-boot-loader-menu)
+TIMEOUT=$(((TIMEOUT_USEC + 500000) / 1000000))
+
+@grub_editenv@ - set menu_show_once_timeout=$TIMEOUT

--- a/util/systemd/systemd-integration.sh.in
+++ b/util/systemd/systemd-integration.sh.in
@@ -4,3 +4,8 @@ TIMEOUT_USEC=$(cat /run/systemd/reboot-to-boot-loader-menu)
 TIMEOUT=$(((TIMEOUT_USEC + 500000) / 1000000))
 
 @grub_editenv@ - set menu_show_once_timeout=$TIMEOUT
+
+# Downstream RH / Fedora patch for compatibility with old, not (yet)
+# regenerated grub.cfg files which miss the menu_show_once_timeout check
+# this older grubenv variable leads to a fixed timeout of 60 seconds
+@grub_editenv@ - set menu_show_once=1


### PR DESCRIPTION
Here are 2 patches which make "systemctl reboot --boot-loader-menu=xx", which is supposed to make the menu shown for xx seconds even if it is hidden by default, work with grub.

This implements the grub side of:
https://fedoraproject.org/wiki/Changes/CleanupGnomeHiddenBootMenuIntegration

Note this also needs the following spec file changes:

```
diff --git a/grub2.spec b/grub2.spec
index f50174d..86ef280 100644
--- a/grub2.spec
+++ b/grub2.spec
@@ -263,8 +263,11 @@ ln -s ../grub-boot-success.timer \
 # Install systemd system-update unit to set boot_indeterminate for offline-upd
 install -D -m 0755 -t %{buildroot}%{_unitdir} docs/grub-boot-indeterminate.service
 install -d -m 0755 %{buildroot}%{_unitdir}/system-update.target.wants
+install -d -m 0755 %{buildroot}%{_unitdir}/reboot.target.wants
 ln -s ../grub-boot-indeterminate.service \
 	%{buildroot}%{_unitdir}/system-update.target.wants
+ln -s ../grub2-systemd-integration.service \
+	%{buildroot}%{_unitdir}/reboot.target.wants
 
 # Don't run debuginfo on all the grub modules and whatnot; it just
 # rejects them, complains, and slows down extraction.
@@ -398,6 +401,9 @@ rm -r /boot/grub2.tmp/ || :
 %{_userunitdir}/timers.target.wants
 %{_unitdir}/grub-boot-indeterminate.service
 %{_unitdir}/system-update.target.wants
+%{_unitdir}/%{name}-systemd-integration.service
+%{_unitdir}/reboot.target.wants
+%{_unitdir}/systemd-logind.service.d
 %{_infodir}/%{name}*
 %{_datarootdir}/grub/*
 %{_sbindir}/%{name}-install
@@ -413,6 +419,7 @@ rm -r /boot/grub2.tmp/ || :
 %{_bindir}/%{name}-mkimage
 %{_bindir}/%{name}-mkrelpath
 %{_bindir}/%{name}-script-check
+%{_libexecdir}/%{name}
 %{_datadir}/man/man?/*
 
 # exclude man pages from tools-extra
```