### PR TITLE
util/grub.d/00_header.in: Change fonts directories priority

### DIFF
--- a/util/grub.d/00_header.in
+++ b/util/grub.d/00_header.in
@@ -152,7 +152,7 @@ if [ "x$gfxterm" = x1 ]; then
 if loadfont `make_system_path_relative_to_its_root "${GRUB_FONT}"` ; then
 EOF
     else
-	for dir in "${pkgdatadir}" "`echo '/@bootdirname@/@grubdirname@' | sed "s,//*,/,g"`" /usr/share/grub ; do
+	for dir in "`echo '/@bootdirname@/@grubdirname@/fonts' | sed "s,//*,/,g"`" "${pkgdatadir}" /usr/share/grub ; do
 	    for basename in unicode unifont ascii; do
 		path="${dir}/${basename}.pf2"
 		if is_path_readable_by_grub "${path}" > /dev/null ; then


### PR DESCRIPTION
Find fonts into the /boot/grub/fonts directory first.