### PR TITLE
fix allocating an extra byte issue

### DIFF
--- a/grub-core/commands/efi/tpm.c
+++ b/grub-core/commands/efi/tpm.c
@@ -283,7 +283,7 @@ grub_tpm2_log_event (grub_efi_handle_t tpm_handle, unsigned char *buf,
     return 0;
 
   event =
-    grub_zalloc (sizeof (EFI_TCG2_EVENT) + grub_strlen (description) + 1);
+    grub_zalloc (sizeof (*event) - sizeof (event->Event) + grub_strlen (description) + 1);
   if (!event)
     return grub_error (GRUB_ERR_OUT_OF_MEMORY,
 		       N_("cannot allocate TPM event buffer"));


### PR DESCRIPTION
Fix the code that allocates an extra byte using grub_zalloc(). This is due to the `Event[1]` field in the following struct adding an extra byte to the struct's size.

```
struct tdEFI_TCG2_EVENT
{                      
  grub_efi_uint32_t     Size;
  EFI_TCG2_EVENT_HEADER Header;
  grub_efi_uint8_t      Event[1];
} GRUB_PACKED;        
typedef struct tdEFI_TCG2_EVENT EFI_TCG2_EVENT;
```

