### PR TITLE
[rhel-8.4] grub-install: disable support for EFI platforms

### DIFF
--- a/docs/grub.texi
+++ b/docs/grub.texi
@@ -6185,6 +6185,13 @@ grub2-install @var{install_device}
 The device name @var{install_device} is an OS device name or a GRUB
 device name.
 
+In order to support UEFI Secure Boot, the resulting GRUB EFI binary must
+be signed by a recognized private key. For this reason, for EFI
+platforms, most distributions also ship prebuilt GRUB EFI binaries
+signed by a distribution-specific private key. In this case, however,
+@command{grub2-install} should not be used because it would overwrite
+the signed EFI binary.
+
 @command{grub2-install} accepts the following options:
 
 @table @option

--- a/util/grub-install.8
+++ b/util/grub-install.8
@@ -1,4 +1,4 @@
-.TH GRUB-INSTALL 1 "Wed Feb 26 2014"
+.TH GRUB-INSTALL 1 "Fri Nov 20 2020"
 .SH NAME
 \fBgrub-install\fR \(em Install GRUB on a device.
 
@@ -30,6 +30,8 @@
 
 .SH DESCRIPTION
 \fBgrub-install\fR installs GRUB onto a device.  This includes copying GRUB images into the target directory (generally \fI/boot/grub\fR), and on some platforms may also include installing GRUB onto a boot sector.
+
+In order to support UEFI Secure Boot, the resulting GRUB EFI binary must be signed by a recognized private key. For this reason, for EFI platforms, most distributions also ship prebuilt GRUB EFI binaries signed by a distribution-specific private key. In this case, however, the \fBgrub-install\fR utility should not be used because it would overwrite the signed EFI binary.
 
 .SH OPTIONS
 .TP

--- a/util/grub-install.c
+++ b/util/grub-install.c
@@ -888,6 +888,22 @@ main (int argc, char *argv[])
 
   platform = grub_install_get_target (grub_install_source_directory);
 
+  switch (platform)
+    {
+    case GRUB_INSTALL_PLATFORM_ARM_EFI:
+    case GRUB_INSTALL_PLATFORM_ARM64_EFI:
+    case GRUB_INSTALL_PLATFORM_I386_EFI:
+    case GRUB_INSTALL_PLATFORM_IA64_EFI:
+    case GRUB_INSTALL_PLATFORM_X86_64_EFI:
+      is_efi = 1;
+      grub_util_error (_("this utility cannot be used for EFI platforms"
+                         " because it does not support UEFI Secure Boot"));
+      break;
+    default:
+      is_efi = 0;
+      break;
+    }
+
   {
     char *platname = grub_install_get_platform_name (platform);
     fprintf (stderr, _("Installing for %s platform.\n"), platname);
@@ -994,26 +1010,7 @@ main (int argc, char *argv[])
   grub_hostfs_init ();
   grub_host_init ();
 
-  switch (platform)
-    {
-    case GRUB_INSTALL_PLATFORM_I386_EFI:
-    case GRUB_INSTALL_PLATFORM_X86_64_EFI:
-    case GRUB_INSTALL_PLATFORM_ARM_EFI:
-    case GRUB_INSTALL_PLATFORM_ARM64_EFI:
-    case GRUB_INSTALL_PLATFORM_IA64_EFI:
-      is_efi = 1;
-      break;
-    default:
-      is_efi = 0;
-      break;
-
-      /* pacify warning.  */
-    case GRUB_INSTALL_PLATFORM_MAX:
-      break;
-    }
-
   /* Find the EFI System Partition.  */
-
   if (is_efi)
     {
       grub_fs_t fs;


### PR DESCRIPTION
For each platform, GRUB is shipped as a kernel image and a set of
modules. These files are then used by the grub-install utility to
install GRUB on a specific device. However, in order to support UEFI
Secure Boot, the resulting EFI binary must be signed by a recognized
private key. For this reason, for EFI platforms, most distributions also
ship prebuilt EFI binaries signed by a distribution-specific private
key. In this case, however, the grub-install utility should not be used
because it would overwrite the signed EFI binary.

The current fix is suboptimal because it preserves all EFI-related code.
A better solution could be to modularize the code and provide a
build-time option.

Resolves: rhbz#1737444