### PR TITLE
password: Fix backspace in username prompt

### DIFF
--- a/grub-core/normal/auth.c
+++ b/grub-core/normal/auth.c
@@ -177,7 +177,9 @@ grub_username_get (char buf[], unsigned buf_size)
 	  if (cur_len)
 	    {
 	      cur_len--;
-	      grub_printf ("\b \b");
+	      grub_printf ("\b");
+	      grub_printf (" ");
+	      grub_printf ("\b");
 	    }
 	  continue;
 	}

--- a/grub-core/normal/charset.c
+++ b/grub-core/normal/charset.c
@@ -931,6 +931,7 @@ grub_bidi_line_logical_to_visual (const grub_uint32_t *logical,
 	    pop_stack ();
 	    break;
 	  case GRUB_BIDI_TYPE_BN:
+	    visual_len++;
 	    break;
 	  case GRUB_BIDI_TYPE_R:
 	  case GRUB_BIDI_TYPE_AL:

--- a/grub-core/term/gfxterm.c
+++ b/grub-core/term/gfxterm.c
@@ -846,8 +846,15 @@ grub_gfxterm_putchar (struct grub_term_output *term,
       switch (c->base)
         {
         case '\b':
-          if (virtual_screen.cursor_x > 0)
-            virtual_screen.cursor_x--;
+	  if (virtual_screen.cursor_x > 0)
+	    {
+	      virtual_screen.cursor_x--;
+	    }
+	  else if (virtual_screen.cursor_y > 0)
+	    {
+	      virtual_screen.cursor_y--;
+	      virtual_screen.cursor_x = virtual_screen.columns-2;
+	    }
           break;
 
         case '\n':


### PR DESCRIPTION
This patch fixes a bug when in the superuser login prompt pressing
backspace key moves the cursor right instead of deleting the
character.

grub_printf appears 3 times because it automatically moves the input
words to the next line if they don't fit into the current one, so
backspase won't work at the end of the terminal line.