### PR TITLE
Enable TDX measurement to RTMR register

### DIFF
--- a/grub-core/Makefile.core.def
+++ b/grub-core/Makefile.core.def
@@ -200,6 +200,7 @@ kernel = {
   efi = kern/efi/acpi.c;
   efi = kern/lockdown.c;
   efi = lib/envblk.c;
+  efi = kern/efi/tdx.c;
   efi = kern/efi/tpm.c;
   i386_coreboot = kern/i386/pc/acpi.c;
   i386_multiboot = kern/i386/pc/acpi.c;

--- a/grub-core/kern/efi/tdx.c
+++ b/grub-core/kern/efi/tdx.c
@@ -1,0 +1,74 @@
+#include <grub/err.h>
+#include <grub/i18n.h>
+#include <grub/efi/api.h>
+#include <grub/efi/efi.h>
+#include <grub/efi/tdx.h>
+#include <grub/mm.h>
+#include <grub/tpm.h>
+#include <grub/tdx.h>
+
+static grub_efi_guid_t tdx_guid = EFI_TD_PROTOCOL_GUID;
+
+static inline grub_err_t grub_tdx_dprintf(grub_efi_status_t status)
+{
+  switch (status) {
+  case GRUB_EFI_SUCCESS:
+    return 0;
+  case GRUB_EFI_DEVICE_ERROR:
+    grub_dprintf ("tdx", "Command failed: 0x%"PRIxGRUB_EFI_STATUS"\n",
+                  status);
+    return GRUB_ERR_IO;
+  case GRUB_EFI_INVALID_PARAMETER:
+    grub_dprintf ("tdx", "Invalid parameter: 0x%"PRIxGRUB_EFI_STATUS"\n",
+                  status);
+    return GRUB_ERR_BAD_ARGUMENT;
+  case GRUB_EFI_VOLUME_FULL:
+    grub_dprintf ("tdx", "Volume is full: 0x%"PRIxGRUB_EFI_STATUS"\n",
+                  status);
+    return GRUB_ERR_BAD_ARGUMENT;
+  case GRUB_EFI_UNSUPPORTED:
+    grub_dprintf ("tdx", "TDX unavailable: 0x%"PRIxGRUB_EFI_STATUS"\n",
+                  status);
+    return GRUB_ERR_UNKNOWN_DEVICE;
+  default:
+    grub_dprintf ("tdx", "Unknown TDX error: 0x%"PRIxGRUB_EFI_STATUS"\n",
+                  status);
+    return GRUB_ERR_UNKNOWN_DEVICE;
+  }
+}
+
+grub_err_t
+grub_tdx_log_event(unsigned char *buf, grub_size_t size, grub_uint8_t pcr,
+		   const char *description)
+{
+  EFI_TD_EVENT *event;
+  grub_efi_status_t status;
+  grub_efi_td_protocol_t *tdx;
+  EFI_TD_MR_INDEX mr;
+
+  tdx = grub_efi_locate_protocol (&tdx_guid, NULL);
+
+  if (!tdx)
+    return 0;
+
+  status = efi_call_3(tdx->map_pcr_to_mr_index, tdx, pcr, &mr);
+  if (status != GRUB_EFI_SUCCESS)
+    return grub_tdx_dprintf(status);
+
+  event = grub_zalloc(sizeof (EFI_TD_EVENT) + grub_strlen(description) + 1);
+  if (!event)
+    return grub_error (GRUB_ERR_OUT_OF_MEMORY,
+		       N_("cannot allocate TD event buffer"));
+
+  event->Header.HeaderSize = sizeof(EFI_TD_EVENT_HEADER);
+  event->Header.HeaderVersion = 1;
+  event->Header.MrIndex = mr;
+  event->Header.EventType = EV_IPL;
+  event->Size = sizeof(*event) - sizeof(event->Event) + grub_strlen(description) + 1;
+  grub_memcpy(event->Event, description, grub_strlen(description) + 1);
+
+  status = efi_call_5 (tdx->hash_log_extend_event, tdx, 0, (unsigned long) buf,
+		       (grub_uint64_t) size, event);
+
+  return grub_tdx_dprintf(status);
+}

--- a/grub-core/kern/tpm.c
+++ b/grub-core/kern/tpm.c
@@ -4,6 +4,7 @@
 #include <grub/mm.h>
 #include <grub/tpm.h>
 #include <grub/term.h>
+#include <grub/tdx.h>
 
 grub_err_t
 grub_tpm_measure (unsigned char *buf, grub_size_t size, grub_uint8_t pcr,
@@ -13,6 +14,9 @@ grub_tpm_measure (unsigned char *buf, grub_size_t size, grub_uint8_t pcr,
   char *desc = grub_xasprintf("%s %s", kind, description);
   if (!desc)
     return GRUB_ERR_OUT_OF_MEMORY;
+
+  grub_tdx_log_event(buf, size, pcr, desc);
+
   ret = grub_tpm_log_event(buf, size, pcr, desc);
   grub_free(desc);
   return ret;

--- a/include/grub/efi/tdx.h
+++ b/include/grub/efi/tdx.h
@@ -1,0 +1,114 @@
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2015  Free Software Foundation, Inc.
+ *
+ *  GRUB is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  GRUB is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef GRUB_EFI_TDX_HEADER
+#define GRUB_EFI_TDX_HEADER 1
+
+#define EFI_TD_PROTOCOL_GUID {0x96751a3d, 0x72f4, 0x41a6, {0xa7, 0x94, 0xed, 0x5d, 0x0e, 0x67, 0xae, 0x6b}};
+
+typedef struct tdEFI_TD_VERSION {
+  grub_efi_uint8_t Major;
+  grub_efi_uint8_t Minor;
+} GRUB_PACKED EFI_TD_VERSION;
+
+typedef grub_efi_uint32_t EFI_TD_EVENT_LOG_BITMAP;
+typedef grub_efi_uint32_t EFI_TD_EVENT_LOG_FORMAT;
+typedef grub_efi_uint32_t EFI_TD_EVENT_ALGORITHM_BITMAP;
+typedef grub_efi_uint32_t EFI_TD_MR_INDEX;
+
+typedef struct tdEFI_TD_EVENT_HEADER {
+  //
+  // Size of the event header itself (sizeof(EFI_TD_EVENT_HEADER)).
+  //
+  grub_efi_uint32_t HeaderSize;
+  //
+  // Header version. For this version of this specification, the value shall be 1.
+  //
+  grub_efi_uint16_t HeaderVersion;
+  //
+  // Index of the MR that shall be extended.
+  //
+  EFI_TD_MR_INDEX MrIndex;
+  //
+  // Type of the event that shall be extended (and optionally logged).
+  //
+  grub_efi_uint32_t EventType;
+} GRUB_PACKED EFI_TD_EVENT_HEADER;
+
+typedef struct tdEFI_TD_EVENT {
+  //
+  // Total size of the event including the Size component, the header and the Event data.
+  //
+  grub_efi_uint32_t Size;
+  EFI_TD_EVENT_HEADER Header;
+  grub_efi_uint8_t Event[1];
+} GRUB_PACKED EFI_TD_EVENT;
+
+typedef struct tdEFI_TD_BOOT_SERVICE_CAPABILITY {
+  //
+  // Allocated size of the structure
+  //
+  grub_efi_uint8_t Size;
+  //
+  // Version of the EFI_TD_BOOT_SERVICE_CAPABILITY structure itself.
+  // For this version of the protocol, the Major version shall be set to 1
+  // and the Minor version shall be set to 1.
+  //
+  EFI_TD_VERSION StructureVersion;
+  //
+  // Version of the EFI TD protocol.
+  // For this version of the protocol, the Major version shall be set to 1
+  // and the Minor version shall be set to 1.
+  //
+  EFI_TD_VERSION ProtocolVersion;
+  //
+  // Supported hash algorithms
+  //
+  EFI_TD_EVENT_ALGORITHM_BITMAP HashAlgorithmBitmap;
+  //
+  // Bitmap of supported event log formats
+  //
+  EFI_TD_EVENT_LOG_BITMAP SupportedEventLogs;
+  //
+  // False = TD not present
+  //
+  grub_efi_boolean_t TdPresentFlag;
+} EFI_TD_BOOT_SERVICE_CAPABILITY;
+
+struct grub_efi_td_protocol
+{
+  grub_efi_status_t (*get_capability) (struct grub_efi_td_protocol *this,
+				       EFI_TD_BOOT_SERVICE_CAPABILITY *ProtocolCapability);
+  grub_efi_status_t (*get_event_log) (struct grub_efi_td_protocol *this,
+				      EFI_TD_EVENT_LOG_FORMAT EventLogFormat,
+				      grub_efi_physical_address_t *EventLogLocation,
+				      grub_efi_physical_address_t *EventLogLastEntry,
+				      grub_efi_boolean_t *EventLogTruncated);
+  grub_efi_status_t (*hash_log_extend_event) (struct grub_efi_td_protocol *this,
+					      grub_efi_uint64_t Flags,
+					      grub_efi_physical_address_t DataToHash,
+					      grub_efi_uint64_t DataToHashLen,
+					      EFI_TD_EVENT *EfiTdEvent);
+  grub_efi_status_t (*map_pcr_to_mr_index) (struct grub_efi_td_protocol *this,
+                                            grub_efi_uint32_t PcrIndex,
+                                            EFI_TD_MR_INDEX *MrIndex);
+};
+
+typedef struct grub_efi_td_protocol grub_efi_td_protocol_t;
+
+#endif

--- a/include/grub/tdx.h
+++ b/include/grub/tdx.h
@@ -1,0 +1,36 @@
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2015  Free Software Foundation, Inc.
+ *
+ *  GRUB is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  GRUB is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef GRUB_TDX_HEADER
+#define GRUB_TDX_HEADER 1
+
+#if defined (GRUB_MACHINE_EFI)
+grub_err_t grub_tdx_log_event(unsigned char *buf, grub_size_t size,
+			      grub_uint8_t pcr, const char *description);
+#else
+static inline grub_err_t grub_tdx_log_event(
+	unsigned char *buf __attribute__ ((unused)),
+	grub_size_t size __attribute__ ((unused)),
+	grub_uint8_t pcr __attribute__ ((unused)),
+	const char *description __attribute__ ((unused)))
+{
+	return 0;
+};
+#endif
+
+#endif


### PR DESCRIPTION
Intel Trust Domain Extensions(Intel TDX) refers to an Intel technology
that extends Virtual Machine Extensions(VMX) and Multi-Key Total Memory
Encryption(MK-TME) with a new kind of virtual machine guest called a
Trust Domain(TD)[1]. A TD runs in a CPU mode that protects the confidentiality
of its memory contents and its CPU state from any other software, including
the hosting Virtual Machine Monitor (VMM).

Trust Domain Virtual Firmware (TDVF) is required to provide TD services to
the TD guest OS.[2] Its reference code is available at https://github.com/tianocore/edk2-staging/tree/TDVF.

To support TD measurement/attestation, TDs provide 4 RTMR registers like
TPM/TPM2 PCR as below:
- RTMR[0] is for TDVF configuration
- RTMR[1] is for the TD OS loader and kernel
- RTMR[2] is for the OS application
- RTMR[3] is reserved for special usage only

This patch adds TD Measurement protocol support along with TPM/TPM2 protocol.

References:
[1] https://software.intel.com/content/dam/develop/external/us/en/documents/tdx-whitepaper-v4.pdf
[2] https://software.intel.com/content/dam/develop/external/us/en/documents/tdx-virtual-firmware-design-guide-rev-1.pdf

Signed-off-by: Lu Ken <ken.lu@intel.com>