### PR TITLE
efi: fix opening and closing net card

### DIFF
--- a/grub-core/net/drivers/efi/efinet.c
+++ b/grub-core/net/drivers/efi/efinet.c
@@ -192,9 +192,6 @@ open_card (struct grub_net_card *dev)
 	  efi_call_6 (net->receive_filters, net, filters, 0, 0, 0, NULL);
 	}
 
-      efi_call_4 (grub_efi_system_table->boot_services->close_protocol,
-		  dev->efi_net, &net_io_guid,
-		  grub_efi_image_handle, dev->efi_handle);
       dev->efi_net = net;
     }
 
@@ -208,8 +205,8 @@ close_card (struct grub_net_card *dev)
   efi_call_1 (dev->efi_net->shutdown, dev->efi_net);
   efi_call_1 (dev->efi_net->stop, dev->efi_net);
   efi_call_4 (grub_efi_system_table->boot_services->close_protocol,
-	      dev->efi_net, &net_io_guid,
-	      grub_efi_image_handle, dev->efi_handle);
+	      dev->efi_handle, &net_io_guid,
+	      grub_efi_image_handle, NULL);
 }
 
 static struct grub_net_card_driver efidriver =


### PR DESCRIPTION
As [UEFI Specification 2.9](https://uefi.org/sites/default/files/resources/UEFI_Spec_2_9_2021_03_18.pdf) P199 said
> EFI_BOOT_SERVICES.CloseProtocol()
Handle The handle for the protocol interface that was previously opened with OpenProtocol(),
and is now being closed. 

`efi_call_4 (grub_efi_system_table->boot_services->close_protocol,...` next argument is wrong, and should make corresponding changes in other places.

According to [UEFI Specification 2.9](https://uefi.org/sites/default/files/resources/UEFI_Spec_2_9_2021_03_18.pdf) P191
> EFI_BOOT_SERVICES.OpenProtocol()
This function opens a protocol interface on the handle specified by Handle for the protocol specified by
Protocol. 

`efi_call_4 (grub_efi_system_table->boot_services->close_protocol,...` shouldn't be called in `open_card` in the context.

Signed-off-by: zhouyou <115989897@qq.com>