### PR TITLE
DejaVu SANS font directory update

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1725,7 +1725,7 @@ fi
 
 if test x"$starfield_excuse" = x; then
    for ext in pcf pcf.gz bdf bdf.gz ttf ttf.gz; do
-     for dir in . /usr/src /usr/share/fonts/X11/misc /usr/share/fonts/truetype/ttf-dejavu /usr/share/fonts/dejavu /usr/share/fonts/truetype; do
+     for dir in . /usr/src /usr/share/fonts/X11/misc /usr/share/fonts/truetype/ttf-dejavu /usr/share/fonts/dejavu /usr/share/fonts/truetype /usr/share/fonts/dejavu-sans-fonts; do
         if test -f "$dir/DejaVuSans.$ext"; then
           DJVU_FONT_SOURCE="$dir/DejaVuSans.$ext"
           break 2


### PR DESCRIPTION
In Fedora 35, and possibly earlier, grub would fail to configure with a complaint about DejaVu being "not found" even though it was installed. The DejaVu sans font search path is updated to reflect the distribution's *current* install path.