### PR TITLE
Enable TDX measurement to RTMR register (v2)

### DIFF
--- a/grub-core/Makefile.core.def
+++ b/grub-core/Makefile.core.def
@@ -200,6 +200,7 @@ kernel = {
   efi = kern/efi/acpi.c;
   efi = kern/lockdown.c;
   efi = lib/envblk.c;
+  efi = kern/efi/cc.c;
   efi = kern/efi/tpm.c;
   i386_coreboot = kern/i386/pc/acpi.c;
   i386_multiboot = kern/i386/pc/acpi.c;

--- a/grub-core/kern/efi/cc.c
+++ b/grub-core/kern/efi/cc.c
@@ -1,0 +1,78 @@
+#include <grub/efi/api.h>
+#include <grub/efi/cc.h>
+#include <grub/efi/efi.h>
+#include <grub/err.h>
+#include <grub/i18n.h>
+#include <grub/mm.h>
+#include <grub/tpm.h>
+#include <grub/cc.h>
+
+static grub_efi_guid_t cc_measurement_guid = EFI_CC_MEASUREMENT_PROTOCOL_GUID;
+
+static inline grub_err_t
+grub_cc_dprintf (grub_efi_status_t status)
+{
+  switch (status)
+    {
+    case GRUB_EFI_SUCCESS:
+      return 0;
+    case GRUB_EFI_DEVICE_ERROR:
+      grub_dprintf ("cc", "Command failed: 0x%" PRIxGRUB_EFI_STATUS "\n",
+                    status);
+      return GRUB_ERR_IO;
+    case GRUB_EFI_INVALID_PARAMETER:
+      grub_dprintf ("cc", "Invalid parameter: 0x%" PRIxGRUB_EFI_STATUS "\n",
+                    status);
+      return GRUB_ERR_BAD_ARGUMENT;
+    case GRUB_EFI_VOLUME_FULL:
+      grub_dprintf ("cc", "Volume is full: 0x%" PRIxGRUB_EFI_STATUS "\n",
+                    status);
+      return GRUB_ERR_BAD_ARGUMENT;
+    case GRUB_EFI_UNSUPPORTED:
+      grub_dprintf ("cc", "CC unavailable: 0x%" PRIxGRUB_EFI_STATUS "\n",
+                    status);
+      return GRUB_ERR_UNKNOWN_DEVICE;
+    default:
+      grub_dprintf ("cc",
+                    "Unknown MEASUREMENT error: 0x%" PRIxGRUB_EFI_STATUS "\n",
+                    status);
+      return GRUB_ERR_UNKNOWN_DEVICE;
+    }
+}
+
+grub_err_t
+grub_cc_log_event (unsigned char *buf, grub_size_t size, grub_uint8_t pcr,
+                   const char *description)
+{
+  EFI_CC_EVENT *event;
+  grub_efi_status_t status;
+  grub_efi_cc_protocol_t *cc;
+  EFI_CC_MR_INDEX mr;
+
+  cc = grub_efi_locate_protocol (&cc_measurement_guid, NULL);
+
+  if (!cc)
+    return 0;
+
+  status = efi_call_3 (cc->map_pcr_to_mr_index, cc, pcr, &mr);
+  if (status != GRUB_EFI_SUCCESS)
+    return grub_cc_dprintf (status);
+
+  event = grub_zalloc (sizeof (EFI_CC_EVENT) + grub_strlen (description) + 1);
+  if (!event)
+    return grub_error (GRUB_ERR_OUT_OF_MEMORY,
+                       N_ ("cannot allocate CC event buffer"));
+
+  event->Header.HeaderSize = sizeof (EFI_CC_EVENT_HEADER);
+  event->Header.HeaderVersion = EFI_CC_EVENT_HEADER_VERSION;
+  event->Header.MrIndex = mr;
+  event->Header.EventType = EV_IPL;
+  event->Size = sizeof (*event) - sizeof (event->Event)
+                + grub_strlen (description) + 1;
+  grub_memcpy (event->Event, description, grub_strlen (description) + 1);
+
+  status = efi_call_5 (cc->hash_log_extend_event, cc, 0, (unsigned long)buf,
+                       (grub_uint64_t)size, event);
+
+  return grub_cc_dprintf (status);
+}

--- a/grub-core/kern/tpm.c
+++ b/grub-core/kern/tpm.c
@@ -4,6 +4,7 @@
 #include <grub/mm.h>
 #include <grub/tpm.h>
 #include <grub/term.h>
+#include <grub/cc.h>
 
 grub_err_t
 grub_tpm_measure (unsigned char *buf, grub_size_t size, grub_uint8_t pcr,
@@ -13,6 +14,9 @@ grub_tpm_measure (unsigned char *buf, grub_size_t size, grub_uint8_t pcr,
   char *desc = grub_xasprintf("%s %s", kind, description);
   if (!desc)
     return GRUB_ERR_OUT_OF_MEMORY;
+
+  grub_cc_log_event(buf, size, pcr, desc);
+
   ret = grub_tpm_log_event(buf, size, pcr, desc);
   grub_free(desc);
   return ret;

--- a/include/grub/cc.h
+++ b/include/grub/cc.h
@@ -1,0 +1,36 @@
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2015  Free Software Foundation, Inc.
+ *
+ *  GRUB is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  GRUB is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef GRUB_CC_HEADER
+#define GRUB_CC_HEADER 1
+
+#if defined (GRUB_MACHINE_EFI)
+grub_err_t grub_cc_log_event(unsigned char *buf, grub_size_t size,
+			     grub_uint8_t pcr, const char *description);
+#else
+static inline grub_err_t grub_cc_log_event(
+	unsigned char *buf __attribute__ ((unused)),
+	grub_size_t size __attribute__ ((unused)),
+	grub_uint8_t pcr __attribute__ ((unused)),
+	const char *description __attribute__ ((unused)))
+{
+	return 0;
+};
+#endif
+
+#endif

--- a/include/grub/efi/cc.h
+++ b/include/grub/efi/cc.h
@@ -1,0 +1,156 @@
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2015  Free Software Foundation, Inc.
+ *
+ *  GRUB is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  GRUB is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef GRUB_EFI_CC_HEADER
+#define GRUB_EFI_CC_HEADER 1
+
+#define EFI_CC_MEASUREMENT_PROTOCOL_GUID \
+  { 0x96751a3d, 0x72f4, 0x41a6, \
+    { 0xa7, 0x94, 0xed, 0x5d, 0x0e, 0x67, 0xae, 0x6b } \
+  };
+
+typedef struct
+{
+  grub_efi_uint8_t Major;
+  grub_efi_uint8_t Minor;
+} EFI_CC_VERSION;
+
+/*
+ * EFI_CC Type/SubType definition
+ */
+#define EFI_CC_TYPE_NONE 0
+#define EFI_CC_TYPE_SEV 1
+#define EFI_CC_TYPE_TDX 2
+
+typedef struct
+{
+  grub_efi_uint8_t Type;
+  grub_efi_uint8_t SubType;
+} EFI_CC_TYPE;
+
+typedef grub_efi_uint32_t EFI_CC_EVENT_LOG_BITMAP;
+typedef grub_efi_uint32_t EFI_CC_EVENT_LOG_FORMAT;
+typedef grub_efi_uint32_t EFI_CC_EVENT_ALGORITHM_BITMAP;
+typedef grub_efi_uint32_t EFI_CC_MR_INDEX;
+
+/*
+ * Intel TDX measure register index
+ */
+#define TDX_MR_INDEX_MRTD 0
+#define TDX_MR_INDEX_RTMR0 1
+#define TDX_MR_INDEX_RTMR1 2
+#define TDX_MR_INDEX_RTMR2 3
+#define TDX_MR_INDEX_RTMR3 4
+
+#define EFI_CC_EVENT_LOG_FORMAT_TCG_2 0x00000002
+#define EFI_CC_BOOT_HASH_ALG_SHA384 0x00000004
+#define EFI_CC_EVENT_HEADER_VERSION 1
+
+typedef struct tdEFI_CC_EVENT_HEADER
+{
+  /*
+   * Size of the event header itself (sizeof(EFI_TD_EVENT_HEADER))
+   */
+  grub_efi_uint32_t HeaderSize;
+
+  /*
+   * Header version. For this version of this specification,
+   * the value shall be 1.
+   */
+  grub_efi_uint16_t HeaderVersion;
+
+  /*
+   * Index of the MR that shall be extended
+   */
+  EFI_CC_MR_INDEX MrIndex;
+
+  /*
+   * Type of the event that shall be extended (and optionally logged)
+   */
+  grub_efi_uint32_t EventType;
+} GRUB_PACKED EFI_CC_EVENT_HEADER;
+
+typedef struct tdEFI_CC_EVENT
+{
+  /*
+   * Total size of the event including the Size component, the header and the
+   * Event data.
+   */
+  grub_efi_uint32_t Size;
+  EFI_CC_EVENT_HEADER Header;
+  grub_efi_uint8_t Event[1];
+} GRUB_PACKED EFI_CC_EVENT;
+
+typedef struct
+{
+  /* Allocated size of the structure */
+  grub_efi_uint8_t Size;
+
+  /*
+   * Version of the EFI_CC_BOOT_SERVICE_CAPABILITY structure itself.
+   * For this version of the protocol, the Major version shall be set to 1
+   * and the Minor version shall be set to 1.
+   */
+  EFI_CC_VERSION StructureVersion;
+
+  /*
+   * Version of the EFI TD protocol.
+   * For this version of the protocol, the Major version shall be set to 1
+   * and the Minor version shall be set to 1.
+   */
+  EFI_CC_VERSION ProtocolVersion;
+
+  /*
+   * Supported hash algorithms
+   */
+  EFI_CC_EVENT_ALGORITHM_BITMAP HashAlgorithmBitmap;
+
+  /*
+   * Bitmap of supported event log formats
+   */
+  EFI_CC_EVENT_LOG_BITMAP SupportedEventLogs;
+
+  /*
+   * Indicates the CC type
+   */
+  EFI_CC_TYPE CcType;
+} EFI_CC_BOOT_SERVICE_CAPABILITY;
+
+struct grub_efi_cc_protocol
+{
+  grub_efi_status_t (*get_capability) (
+      struct grub_efi_cc_protocol *this,
+      EFI_CC_BOOT_SERVICE_CAPABILITY *ProtocolCapability);
+  grub_efi_status_t (*get_event_log) (
+      struct grub_efi_cc_protocol *this,
+      EFI_CC_EVENT_LOG_FORMAT EventLogFormat,
+      grub_efi_physical_address_t *EventLogLocation,
+      grub_efi_physical_address_t *EventLogLastEntry,
+      grub_efi_boolean_t *EventLogTruncated);
+  grub_efi_status_t (*hash_log_extend_event) (
+      struct grub_efi_cc_protocol *this, grub_efi_uint64_t Flags,
+      grub_efi_physical_address_t DataToHash, grub_efi_uint64_t DataToHashLen,
+      EFI_CC_EVENT *EfiCcEvent);
+  grub_efi_status_t (*map_pcr_to_mr_index) (struct grub_efi_cc_protocol *this,
+                                            grub_efi_uint32_t PcrIndex,
+                                            EFI_CC_MR_INDEX *MrIndex);
+};
+
+typedef struct grub_efi_cc_protocol grub_efi_cc_protocol_t;
+
+#endif


### PR DESCRIPTION
Intel Trust Domain Extensions(Intel TDX) refers to an Intel technology
that extends Virtual Machine Extensions(VMX) and Multi-Key Total Memory
Encryption(MK-TME) with a new kind of virtual machine guest called a
Trust Domain(TD)[1]. A TD runs in a CPU mode that protects the confidentiality
of its memory contents and its CPU state from any other software, including
the hosting Virtual Machine Monitor (VMM).

Trust Domain Virtual Firmware (TDVF) is required to provide Intel TDX
implementation and service for EFI_CC_MEASUREMENT_PROTOCOL[2]. The bugzilla
for TDVF is at https://bugzilla.tianocore.org/show_bug.cgi?id=3625.

To support CC measurement/attestation with Intel TDX technology, following 4
RTMR registers will be extended by TDX service like TPM/TPM2 PCR:
- RTMR[0] is for TDVF configuration
- RTMR[1] is for the TD OS loader and kernel
- RTMR[2] is for the OS application
- RTMR[3] is reserved for special usage only

This patch adds TDX Implementation for CC Measurement protocol along with
TPM/TPM2 protocol.

References:
[1] https://software.intel.com/content/dam/develop/external/us/en/documents/tdx-whitepaper-v4.pdf
[2] https://software.intel.com/content/dam/develop/external/us/en/documents/tdx-virtual-firmware-design-guide-rev-1.pdf
[3] https://software.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface-1.0-344426-002.pdf

Signed-off-by: Lu Ken <ken.lu@intel.com>