### PR TITLE
Make sure EFI disk controllers are connected when discovering devices

### DIFF
--- a/grub-core/disk/efi/efidisk.c
+++ b/grub-core/disk/efi/efidisk.c
@@ -65,6 +65,12 @@ make_devices (void)
       struct grub_efidisk_data *d;
       grub_efi_block_io_t *bio;
 
+      grub_efi_status_t status;
+
+      status = grub_efi_connect_controller(*handle, NULL, NULL, 1);
+      grub_dprintf ("efidisk", "connect_controller(%p) returned %d\n",
+		    *handle, (int)status);
+
       dp = grub_efi_get_device_path (*handle);
       if (! dp)
 	continue;

--- a/grub-core/kern/efi/efi.c
+++ b/grub-core/kern/efi/efi.c
@@ -95,6 +95,19 @@ grub_efi_locate_handle (grub_efi_locate_search_type_t search_type,
   return buffer;
 }
 
+grub_efi_status_t
+grub_efi_connect_controller (grub_efi_handle_t controller_handle,
+			     grub_efi_handle_t *driver_image_handle,
+			     grub_efi_device_path_protocol_t *remaining_device_path,
+			     grub_efi_boolean_t recursive)
+{
+  grub_efi_boot_services_t *b;
+
+  b = grub_efi_system_table->boot_services;
+  return efi_call_4 (b->connect_controller, controller_handle,
+		     driver_image_handle, remaining_device_path, recursive);
+}
+
 void *
 grub_efi_open_protocol (grub_efi_handle_t handle,
 			grub_efi_guid_t *protocol,

--- a/grub-core/loader/efi/chainloader.c
+++ b/grub-core/loader/efi/chainloader.c
@@ -251,7 +251,11 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
     goto fail;
 
   if (dev->disk)
-    dev_handle = grub_efidisk_get_device_handle (dev->disk);
+    {
+      dev_handle = grub_efidisk_get_device_handle (dev->disk);
+      if (! dev_handle)
+	grub_dprintf ("chain", "grub_efidisk_get_device_handle(%s) failed\n", filename);
+    }
   else if (dev->net && dev->net->server)
     {
       grub_net_network_level_address_t addr;
@@ -268,6 +272,8 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
 	goto fail;
 
       dev_handle = grub_efinet_get_device_handle (inf->card);
+      if (! dev_handle)
+	grub_dprintf ("chain", "grub_efidisk_get_device_handle(%s) failed\n", filename);
     }
 
   if (dev_handle)
@@ -275,7 +281,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
 
   if (! dp)
     {
-      grub_error (GRUB_ERR_BAD_DEVICE, "not a valid root device");
+      grub_error (GRUB_ERR_BAD_DEVICE, "%s: not a valid root device", filename);
       goto fail;
     }
 

--- a/include/grub/efi/efi.h
+++ b/include/grub/efi/efi.h
@@ -32,6 +32,11 @@ EXPORT_FUNC(grub_efi_locate_handle) (grub_efi_locate_search_type_t search_type,
 				     grub_efi_guid_t *protocol,
 				     void *search_key,
 				     grub_efi_uintn_t *num_handles);
+grub_efi_status_t
+EXPORT_FUNC(grub_efi_connect_controller) (grub_efi_handle_t controller_handle,
+					  grub_efi_handle_t *driver_image_handle,
+					  grub_efi_device_path_protocol_t *remaining_device_path,
+					  grub_efi_boolean_t recursive);
 void *EXPORT_FUNC(grub_efi_open_protocol) (grub_efi_handle_t handle,
 					   grub_efi_guid_t *protocol,
 					   grub_efi_uint32_t attributes);


### PR DESCRIPTION
When `efi.quickboot` is enabled on VMWare (hardware release 16 and later), it may happen that not all EFI devices are connected. Due to this, browsing the devices in `make_devices()` just fails to find devices, in particular partitions for a given disk.
This typically happens when network booting, then trying to chainload to local disk (this is used in deployment tools such as Red Hat Satellite).

This patch makes sure the controller is connected before browsing its underlying devices. It blindly calls the EFI `ConnectController` function with recursive option and just ignores the result, which is 0 (EFI_SUCCESS) or 14 (EFI_NOT_FOUND) when the handle is not a controller.
