### PR TITLE
Backport rhel 9.0 support for loading initrd above 4 GB to rhel 8.6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -66,7 +66,7 @@ New in 2.02:
   * Prefer pmtimer for TSC calibration.
 
 * New/improved platform support:
-  * New `efifwsetup' and `lsefi' commands on EFI platforms.
+  * New `efifwsetup', `lsefi' and `connectefi` commands on EFI platforms.
   * New `cmosdump' and `cmosset' commands on platforms with CMOS support.
   * New command `pcidump' for PCI platforms.
   * Improve opcode parsing in ACPI halt implementation.

--- a/grub-core/Makefile.core.def
+++ b/grub-core/Makefile.core.def
@@ -780,6 +780,12 @@ module = {
 };
 
 module = {
+  name = connectefi;
+  common = commands/efi/connectefi.c;
+  enable = efi;
+};
+
+module = {
   name = blocklist;
   common = commands/blocklist.c;
 };

--- a/grub-core/commands/efi/connectefi.c
+++ b/grub-core/commands/efi/connectefi.c
@@ -1,0 +1,205 @@
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2022  Free Software Foundation, Inc.
+ *
+ *  GRUB is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  GRUB is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <grub/types.h>
+#include <grub/mm.h>
+#include <grub/misc.h>
+#include <grub/efi/api.h>
+#include <grub/efi/pci.h>
+#include <grub/efi/efi.h>
+#include <grub/command.h>
+#include <grub/err.h>
+#include <grub/i18n.h>
+
+GRUB_MOD_LICENSE ("GPLv3+");
+
+typedef struct handle_list
+{
+  grub_efi_handle_t handle;
+  struct handle_list *next;
+} handle_list_t;
+
+static handle_list_t *already_handled = NULL;
+
+static grub_err_t
+add_handle (grub_efi_handle_t handle)
+{
+  handle_list_t *e;
+  e = grub_malloc (sizeof (*e));
+  if (! e)
+    return grub_errno;
+  e->handle = handle;
+  e->next = already_handled;
+  already_handled = e;
+  return GRUB_ERR_NONE;
+}
+
+static int
+is_in_list (grub_efi_handle_t handle)
+{
+  handle_list_t *e;
+  for (e = already_handled; e != NULL; e = e->next)
+    if (e->handle == handle)
+      return 1;
+  return 0;
+}
+
+static void
+free_handle_list (void)
+{
+  handle_list_t *e;
+  while ((e = already_handled) != NULL)
+    {
+      already_handled = already_handled->next;
+      grub_free (e);
+    }
+}
+
+typedef enum searched_item_flag
+{
+  SEARCHED_ITEM_FLAG_LOOP = 1,
+  SEARCHED_ITEM_FLAG_RECURSIVE = 2
+} searched_item_flags;
+
+typedef struct searched_item
+{
+  grub_efi_guid_t guid;
+  const char *name;
+  searched_item_flags flags;
+} searched_items;
+
+static grub_err_t
+grub_cmd_connectefi (grub_command_t cmd __attribute__ ((unused)),
+		     int argc, char **args)
+{
+  unsigned s;
+  searched_items pciroot_items[] =
+    {
+      { GRUB_EFI_PCI_ROOT_IO_GUID, "PCI root", SEARCHED_ITEM_FLAG_RECURSIVE }
+    };
+  searched_items scsi_items[] =
+    {
+      { GRUB_EFI_PCI_ROOT_IO_GUID, "PCI root", 0 },
+      { GRUB_EFI_PCI_IO_GUID, "PCI", SEARCHED_ITEM_FLAG_LOOP },
+      { GRUB_EFI_SCSI_IO_PROTOCOL_GUID, "SCSI I/O", SEARCHED_ITEM_FLAG_RECURSIVE }
+    };
+  searched_items *items = NULL;
+  unsigned nitems = 0;
+  grub_err_t grub_err = GRUB_ERR_NONE;
+  unsigned total_connected = 0;
+
+  if (argc != 1)
+    return grub_error (GRUB_ERR_BAD_ARGUMENT, N_("one argument expected"));
+
+  if (grub_strcmp(args[0], N_("pciroot")) == 0)
+    {
+      items = pciroot_items;
+      nitems = ARRAY_SIZE (pciroot_items);
+    }
+  else if (grub_strcmp(args[0], N_("scsi")) == 0)
+    {
+      items = scsi_items;
+      nitems = ARRAY_SIZE (scsi_items);
+    }
+  else
+    return grub_error (GRUB_ERR_BAD_ARGUMENT,
+		       N_("unexpected argument `%s'"), args[0]);
+
+  for (s = 0; s < nitems; s++)
+    {
+      grub_efi_handle_t *handles;
+      grub_efi_uintn_t num_handles;
+      unsigned i, connected = 0, loop = 0;
+
+loop:
+      loop++;
+      grub_dprintf ("efi", "step '%s' loop %d:\n", items[s].name, loop);
+
+      handles = grub_efi_locate_handle (GRUB_EFI_BY_PROTOCOL,
+					&items[s].guid, 0, &num_handles);
+
+      if (!handles)
+	continue;
+
+      for (i = 0; i < num_handles; i++)
+	{
+	  grub_efi_handle_t handle = handles[i];
+	  grub_efi_status_t status;
+	  unsigned j;
+
+	  /* Skip already handled handles  */
+	  if (is_in_list (handle))
+	    {
+	      grub_dprintf ("efi", "  handle %p: already processed\n",
+				   handle);
+	      continue;
+	    }
+
+	  status = grub_efi_connect_controller(handle, NULL, NULL,
+			items[s].flags & SEARCHED_ITEM_FLAG_RECURSIVE ? 1 : 0);
+	  if (status == GRUB_EFI_SUCCESS)
+	    {
+	      connected++;
+	      total_connected++;
+	      grub_dprintf ("efi", "  handle %p: connected\n", handle);
+	    }
+	  else
+	    grub_dprintf ("efi", "  handle %p: failed to connect (%d)\n",
+				 handle, (grub_efi_int8_t) status);
+
+	  if ((grub_err = add_handle (handle)) != GRUB_ERR_NONE)
+	    break; /* fatal  */
+	}
+
+      grub_free (handles);
+      if (grub_err != GRUB_ERR_NONE)
+	break; /* fatal  */
+
+      if (items[s].flags & SEARCHED_ITEM_FLAG_LOOP && connected)
+	{
+	  connected = 0;
+	  goto loop;
+	}
+
+      free_handle_list ();
+    }
+
+  free_handle_list ();
+
+  if (total_connected)
+    grub_efidisk_reenumerate_disks ();
+
+  return grub_err;
+}
+
+static grub_command_t cmd;
+
+GRUB_MOD_INIT(connectefi)
+{
+  cmd = grub_register_command ("connectefi", grub_cmd_connectefi,
+			       N_("pciroot|scsi"),
+			       N_("Connect EFI handles."
+				  " If 'pciroot' is specified, connect PCI"
+				  " root EFI handles recursively."
+				  " If 'scsi' is specified, connect SCSI"
+				  " I/O EFI handles recursively."));
+}
+
+GRUB_MOD_FINI(connectefi)
+{
+  grub_unregister_command (cmd);
+}

--- a/grub-core/commands/efi/lsefi.c
+++ b/grub-core/commands/efi/lsefi.c
@@ -19,6 +19,7 @@
 #include <grub/mm.h>
 #include <grub/misc.h>
 #include <grub/efi/api.h>
+#include <grub/efi/disk.h>
 #include <grub/efi/edid.h>
 #include <grub/efi/pci.h>
 #include <grub/efi/efi.h>

--- a/grub-core/commands/search.c
+++ b/grub-core/commands/search.c
@@ -47,7 +47,7 @@ struct search_ctx
 {
   const char *key;
   const char *var;
-  int no_floppy;
+  enum search_flags flags;
   char **hints;
   unsigned nhints;
   int count;
@@ -62,9 +62,28 @@ iterate_device (const char *name, void *data)
   int found = 0;
 
   /* Skip floppy drives when requested.  */
-  if (ctx->no_floppy &&
+  if (ctx->flags & SEARCH_FLAGS_NO_FLOPPY &&
       name[0] == 'f' && name[1] == 'd' && name[2] >= '0' && name[2] <= '9')
     return 0;
+
+  /* Limit to EFI disks when requested.  */
+  if (ctx->flags & SEARCH_FLAGS_EFIDISK_ONLY)
+    {
+      grub_device_t dev;
+      dev = grub_device_open (name);
+      if (! dev)
+	{
+	  grub_errno = GRUB_ERR_NONE;
+	  return 0;
+	}
+      if (! dev->disk || dev->disk->dev->id != GRUB_DISK_DEVICE_EFIDISK_ID)
+	{
+	  grub_device_close (dev);
+	  grub_errno = GRUB_ERR_NONE;
+	  return 0;
+	}
+      grub_device_close (dev);
+    }
 
 #ifdef DO_SEARCH_FS_UUID
 #define compare_fn grub_strcasecmp
@@ -261,13 +280,13 @@ try (struct search_ctx *ctx)
 }
 
 void
-FUNC_NAME (const char *key, const char *var, int no_floppy,
+FUNC_NAME (const char *key, const char *var, enum search_flags flags,
 	   char **hints, unsigned nhints)
 {
   struct search_ctx ctx = {
     .key = key,
     .var = var,
-    .no_floppy = no_floppy,
+    .flags = flags,
     .hints = hints,
     .nhints = nhints,
     .count = 0,

--- a/grub-core/commands/search.c
+++ b/grub-core/commands/search.c
@@ -64,7 +64,7 @@ iterate_device (const char *name, void *data)
   /* Skip floppy drives when requested.  */
   if (ctx->no_floppy &&
       name[0] == 'f' && name[1] == 'd' && name[2] >= '0' && name[2] <= '9')
-    return 1;
+    return 0;
 
 #ifdef DO_SEARCH_FS_UUID
 #define compare_fn grub_strcasecmp

--- a/grub-core/commands/search_wrap.c
+++ b/grub-core/commands/search_wrap.c
@@ -40,6 +40,7 @@ static const struct grub_arg_option options[] =
      N_("Set a variable to the first device found."), N_("VARNAME"),
      ARG_TYPE_STRING},
     {"no-floppy",	'n', 0, N_("Do not probe any floppy drive."), 0, 0},
+    {"efidisk-only",	0, 0, N_("Only probe EFI disks."), 0, 0},
     {"hint",	        'h', GRUB_ARG_OPTION_REPEATABLE,
      N_("First try the device HINT. If HINT ends in comma, "
 	"also try subpartitions"), N_("HINT"), ARG_TYPE_STRING},
@@ -73,6 +74,7 @@ enum options
     SEARCH_FS_UUID,
     SEARCH_SET,
     SEARCH_NO_FLOPPY,
+    SEARCH_EFIDISK_ONLY,
     SEARCH_HINT,
     SEARCH_HINT_IEEE1275,
     SEARCH_HINT_BIOS,
@@ -89,6 +91,7 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
   const char *id = 0;
   int i = 0, j = 0, nhints = 0;
   char **hints = NULL;
+  enum search_flags flags;
 
   if (state[SEARCH_HINT].set)
     for (i = 0; state[SEARCH_HINT].args[i]; i++)
@@ -180,15 +183,18 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
       goto out;
     }
 
+  if (state[SEARCH_NO_FLOPPY].set)
+    flags |= SEARCH_FLAGS_NO_FLOPPY;
+
+  if (state[SEARCH_EFIDISK_ONLY].set)
+    flags |= SEARCH_FLAGS_EFIDISK_ONLY;
+
   if (state[SEARCH_LABEL].set)
-    grub_search_label (id, var, state[SEARCH_NO_FLOPPY].set, 
-		       hints, nhints);
+    grub_search_label (id, var, flags, hints, nhints);
   else if (state[SEARCH_FS_UUID].set)
-    grub_search_fs_uuid (id, var, state[SEARCH_NO_FLOPPY].set,
-			 hints, nhints);
+    grub_search_fs_uuid (id, var, flags, hints, nhints);
   else if (state[SEARCH_FILE].set)
-    grub_search_fs_file (id, var, state[SEARCH_NO_FLOPPY].set, 
-			 hints, nhints);
+    grub_search_fs_file (id, var, flags, hints, nhints);
   else
     grub_error (GRUB_ERR_INVALID_COMMAND, "unspecified search type");
 

--- a/grub-core/disk/efi/efidisk.c
+++ b/grub-core/disk/efi/efidisk.c
@@ -390,6 +390,19 @@ enumerate_disks (void)
   free_devices (devices);
 }
 
+void
+grub_efidisk_reenumerate_disks (void)
+{
+  free_devices (fd_devices);
+  free_devices (hd_devices);
+  free_devices (cd_devices);
+  fd_devices = 0;
+  hd_devices = 0;
+  cd_devices = 0;
+
+  enumerate_disks ();
+}
+
 static int
 grub_efidisk_iterate (grub_disk_dev_iterate_hook_t hook, void *hook_data,
 		      grub_disk_pull_t pull)

--- a/grub-core/kern/efi/efi.c
+++ b/grub-core/kern/efi/efi.c
@@ -95,6 +95,19 @@ grub_efi_locate_handle (grub_efi_locate_search_type_t search_type,
   return buffer;
 }
 
+grub_efi_status_t
+grub_efi_connect_controller (grub_efi_handle_t controller_handle,
+			     grub_efi_handle_t *driver_image_handle,
+			     grub_efi_device_path_protocol_t *remaining_device_path,
+			     grub_efi_boolean_t recursive)
+{
+  grub_efi_boot_services_t *b;
+
+  b = grub_efi_system_table->boot_services;
+  return efi_call_4 (b->connect_controller, controller_handle,
+		     driver_image_handle, remaining_device_path, recursive);
+}
+
 void *
 grub_efi_open_protocol (grub_efi_handle_t handle,
 			grub_efi_guid_t *protocol,

--- a/grub-core/kern/efi/mm.c
+++ b/grub-core/kern/efi/mm.c
@@ -122,7 +122,7 @@ grub_efi_allocate_pages_max (grub_efi_physical_address_t max,
   grub_efi_boot_services_t *b;
   grub_efi_physical_address_t address = max;
 
-  if (max > 0xffffffff)
+  if (max > GRUB_EFI_MAX_USABLE_ADDRESS)
     return 0;
 
   b = grub_efi_system_table->boot_services;
@@ -472,7 +472,7 @@ filter_memory_map (grub_efi_memory_descriptor_t *memory_map,
     {
       if (desc->type == GRUB_EFI_CONVENTIONAL_MEMORY
 #if 1
-	  && desc->physical_start <= GRUB_EFI_MAX_USABLE_ADDRESS
+	  && desc->physical_start <= GRUB_EFI_MAX_ALLOCATION_ADDRESS
 #endif
 	  && desc->physical_start + PAGES_TO_BYTES (desc->num_pages) > 0x100000
 	  && desc->num_pages != 0)
@@ -490,9 +490,9 @@ filter_memory_map (grub_efi_memory_descriptor_t *memory_map,
 #if 1
 	  if (BYTES_TO_PAGES (filtered_desc->physical_start)
 	      + filtered_desc->num_pages
-	      > BYTES_TO_PAGES_DOWN (GRUB_EFI_MAX_USABLE_ADDRESS))
+	      > BYTES_TO_PAGES_DOWN (GRUB_EFI_MAX_ALLOCATION_ADDRESS))
 	    filtered_desc->num_pages
-	      = (BYTES_TO_PAGES_DOWN (GRUB_EFI_MAX_USABLE_ADDRESS)
+	      = (BYTES_TO_PAGES_DOWN (GRUB_EFI_MAX_ALLOCATION_ADDRESS)
 		 - BYTES_TO_PAGES (filtered_desc->physical_start));
 #endif
 

--- a/grub-core/loader/i386/efi/linux.c
+++ b/grub-core/loader/i386/efi/linux.c
@@ -37,10 +37,15 @@ static grub_dl_t my_mod;
 static int loaded;
 static void *kernel_mem;
 static grub_uint64_t kernel_size;
-static grub_uint8_t *initrd_mem;
+static void *initrd_mem;
 static grub_uint32_t handover_offset;
 struct linux_kernel_params *params;
 static char *linux_cmdline;
+
+#define MIN(a, b) \
+  ({ typeof (a) _a = (a); \
+     typeof (b) _b = (b); \
+     _a < _b ? _a : _b; })
 
 #define BYTES_TO_PAGES(bytes)   (((bytes) + 0xfff) >> 12)
 
@@ -73,6 +78,44 @@ grub_linuxefi_unload (void)
     grub_efi_free_pages ((grub_efi_physical_address_t)(grub_addr_t)params,
 			 BYTES_TO_PAGES(16384));
   return GRUB_ERR_NONE;
+}
+
+#define BOUNCE_BUFFER_MAX 0x10000000ull
+
+static grub_ssize_t
+read(grub_file_t file, grub_uint8_t *bufp, grub_size_t len)
+{
+  grub_ssize_t bufpos = 0;
+  static grub_size_t bbufsz = 0;
+  static char *bbuf = NULL;
+
+  if (bbufsz == 0)
+    bbufsz = MIN(BOUNCE_BUFFER_MAX, len);
+
+  while (!bbuf && bbufsz)
+    {
+      bbuf = grub_malloc(bbufsz);
+      if (!bbuf)
+	bbufsz >>= 1;
+    }
+  if (!bbuf)
+    grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("cannot allocate bounce buffer"));
+
+  while (bufpos < (long long)len)
+    {
+      grub_ssize_t sz;
+
+      sz = grub_file_read (file, bbuf, MIN(bbufsz, len - bufpos));
+      if (sz < 0)
+	return sz;
+      if (sz == 0)
+	break;
+
+      grub_memcpy(bufp + bufpos, bbuf, sz);
+      bufpos += sz;
+    }
+
+  return bufpos;
 }
 
 static grub_err_t
@@ -133,7 +176,7 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
   for (i = 0; i < nfiles; i++)
     {
       grub_ssize_t cursize = grub_file_size (files[i]);
-      if (grub_file_read (files[i], ptr, cursize) != cursize)
+      if (read (files[i], ptr, cursize) != cursize)
         {
           if (!grub_errno)
             grub_error (GRUB_ERR_FILE_READ_ERROR, N_("premature end of file %s"),
@@ -160,11 +203,6 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
 
   return grub_errno;
 }
-
-#define MIN(a, b) \
-  ({ typeof (a) _a = (a); \
-     typeof (b) _b = (b); \
-     _a < _b ? _a : _b; })
 
 static grub_err_t
 grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),

--- a/grub-core/loader/i386/efi/linux.c
+++ b/grub-core/loader/i386/efi/linux.c
@@ -54,13 +54,22 @@ struct allocation_choice {
     grub_efi_allocate_type_t alloc_type;
 };
 
-static struct allocation_choice max_addresses[] =
+static struct allocation_choice max_addresses[4] =
   {
+    /* the kernel overrides this one with pref_address and
+     * GRUB_EFI_ALLOCATE_ADDRESS */
     { GRUB_EFI_MAX_ALLOCATION_ADDRESS, GRUB_EFI_ALLOCATE_MAX_ADDRESS },
+    /* this one is always below 4GB, which we still *prefer* even if the flag
+     * is set. */
     { GRUB_EFI_MAX_ALLOCATION_ADDRESS, GRUB_EFI_ALLOCATE_MAX_ADDRESS },
+    /* If the flag in params is set, this one gets changed to be above 4GB. */
     { GRUB_EFI_MAX_ALLOCATION_ADDRESS, GRUB_EFI_ALLOCATE_MAX_ADDRESS },
     { 0, 0 }
   };
+static struct allocation_choice saved_addresses[4];
+
+#define save_addresses() grub_memcpy(saved_addresses, max_addresses, sizeof(max_addresses))
+#define restore_addresses() grub_memcpy(max_addresses, saved_addresses, sizeof(max_addresses))
 
 static inline void
 kernel_free(void *addr, grub_efi_uintn_t size)
@@ -82,6 +91,11 @@ kernel_alloc(grub_efi_uintn_t size, const char * const errmsg)
       grub_uint64_t max = max_addresses[i].addr;
       grub_efi_uintn_t pages;
 
+      /*
+       * When we're *not* loading the kernel, or >4GB allocations aren't
+       * supported, these entries are basically all the same, so don't re-try
+       * the same parameters.
+       */
       if (max == prev_max)
 	continue;
 
@@ -170,6 +184,9 @@ read(grub_file_t file, grub_uint8_t *bufp, grub_size_t len)
   return bufpos;
 }
 
+#define LOW_U32(val) ((grub_uint32_t)(((grub_addr_t)(val)) & 0xffffffffull))
+#define HIGH_U32(val) ((grub_uint32_t)(((grub_addr_t)(val) >> 32) & 0xffffffffull))
+
 static grub_err_t
 grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
                  int argc, char *argv[])
@@ -214,8 +231,12 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
     goto fail;
   grub_dprintf ("linux", "initrd_mem = %p\n", initrd_mem);
 
-  params->ramdisk_size = size;
-  params->ramdisk_image = initrd_mem;
+  params->ramdisk_size = LOW_U32(size);
+  params->ramdisk_image = LOW_U32(initrd_mem);
+#if defined(__x86_64__)
+  params->ext_ramdisk_size = HIGH_U32(size);
+  params->ext_ramdisk_image = HIGH_U32(initrd_mem);
+#endif
 
   ptr = initrd_mem;
 
@@ -353,6 +374,18 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
     }
 #endif
 
+#if defined(__x86_64__)
+  if (lh->xloadflags & LINUX_XLF_CAN_BE_LOADED_ABOVE_4G)
+    {
+      grub_dprintf ("linux", "Loading kernel above 4GB is supported; enabling.\n");
+      max_addresses[2].addr = GRUB_EFI_MAX_USABLE_ADDRESS;
+    }
+  else
+    {
+      grub_dprintf ("linux", "Loading kernel above 4GB is not supported\n");
+    }
+#endif
+
   params = kernel_alloc (sizeof(*params), "cannot allocate kernel parameters");
   if (!params)
     goto fail;
@@ -387,21 +420,40 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 
   grub_dprintf ("linux", "cmdline:%s\n", linux_cmdline);
   grub_dprintf ("linux", "setting lh->cmd_line_ptr to 0x%08x\n",
-		linux_cmdline);
-  lh->cmd_line_ptr = linux_cmdline;
+		LOW_U32(linux_cmdline));
+  lh->cmd_line_ptr = LOW_U32(linux_cmdline);
+#if defined(__x86_64__)
+  if ((grub_efi_uintn_t)linux_cmdline > 0xffffffffull)
+    {
+      grub_dprintf ("linux", "setting params->ext_cmd_line_ptr to 0x%08x\n",
+		    HIGH_U32(linux_cmdline));
+      params->ext_cmd_line_ptr = HIGH_U32(linux_cmdline);
+    }
+#endif
 
   handover_offset = lh->handover_offset;
   grub_dprintf("linux", "handover_offset: 0x%08x\n", handover_offset);
 
   start = (lh->setup_sects + 1) * 512;
 
+  /*
+   * AFAICS >4GB for kernel *cannot* work because of params->code32_start being
+   * 32-bit and getting called unconditionally in head_64.S from either entry
+   * point.
+   *
+   * so nerf that out here...
+   */
+  save_addresses();
   grub_dprintf ("linux", "lh->pref_address: %p\n", (void *)(grub_addr_t)lh->pref_address);
   if (lh->pref_address < (grub_uint64_t)GRUB_EFI_MAX_ALLOCATION_ADDRESS)
     {
       max_addresses[0].addr = lh->pref_address;
       max_addresses[0].alloc_type = GRUB_EFI_ALLOCATE_ADDRESS;
     }
+  max_addresses[1].addr = GRUB_EFI_MAX_ALLOCATION_ADDRESS;
+  max_addresses[2].addr = GRUB_EFI_MAX_ALLOCATION_ADDRESS;
   kernel_mem = kernel_alloc (lh->init_size, N_("can't allocate kernel"));
+  restore_addresses();
   if (!kernel_mem)
     goto fail;
   grub_dprintf("linux", "kernel_mem = %p\n", kernel_mem);
@@ -410,8 +462,9 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 
   loaded = 1;
 
-  grub_dprintf ("linux", "setting lh->code32_start to %p\n", kernel_mem);
-  lh->code32_start = (grub_uint32_t)(grub_addr_t) kernel_mem;
+  grub_dprintf ("linux", "setting lh->code32_start to 0x%08x\n",
+		LOW_U32(kernel_mem));
+  lh->code32_start = LOW_U32(kernel_mem);
 
   grub_memcpy (kernel_mem, (char *)kernel + start, filelen - start);
 

--- a/grub-core/loader/i386/efi/linux.c
+++ b/grub-core/loader/i386/efi/linux.c
@@ -27,6 +27,7 @@
 #include <grub/lib/cmdline.h>
 #include <grub/efi/efi.h>
 #include <grub/efi/linux.h>
+#include <grub/cpu/efi/memory.h>
 #include <grub/tpm.h>
 #include <grub/safemath.h>
 
@@ -113,7 +114,9 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
 	}
     }
 
-  initrd_mem = grub_efi_allocate_pages_max (0x3fffffff, BYTES_TO_PAGES(size));
+  initrd_mem = grub_efi_allocate_pages_max (GRUB_EFI_MAX_ALLOCATION_ADDRESS, BYTES_TO_PAGES(size));
+  if (!initrd_mem)
+    initrd_mem = grub_efi_allocate_pages_max (GRUB_EFI_MAX_USABLE_ADDRESS, BYTES_TO_PAGES(size));
   if (!initrd_mem)
     {
       grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("can't allocate initrd"));
@@ -217,8 +220,11 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 	}
     }
 
-  params = grub_efi_allocate_pages_max (0x3fffffff,
+  params = grub_efi_allocate_pages_max (GRUB_EFI_MAX_ALLOCATION_ADDRESS,
 					BYTES_TO_PAGES(sizeof(*params)));
+  if (!params)
+    params = grub_efi_allocate_pages_max (GRUB_EFI_MAX_USABLE_ADDRESS,
+					  BYTES_TO_PAGES(sizeof(*params)));
   if (! params)
     {
       grub_error (GRUB_ERR_OUT_OF_MEMORY, "cannot allocate kernel parameters");
@@ -288,8 +294,11 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 #endif
 
   grub_dprintf ("linux", "setting up cmdline\n");
-  linux_cmdline = grub_efi_allocate_pages_max(0x3fffffff,
-					 BYTES_TO_PAGES(lh->cmdline_size + 1));
+  linux_cmdline = grub_efi_allocate_pages_max(GRUB_EFI_MAX_ALLOCATION_ADDRESS,
+					      BYTES_TO_PAGES(lh->cmdline_size + 1));
+  if (!linux_cmdline)
+    linux_cmdline = grub_efi_allocate_pages_max(GRUB_EFI_MAX_USABLE_ADDRESS,
+						BYTES_TO_PAGES(lh->cmdline_size + 1));
   if (!linux_cmdline)
     {
       grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("can't allocate cmdline"));
@@ -316,11 +325,12 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 
   kernel_mem = grub_efi_allocate_pages_max(lh->pref_address,
 					   BYTES_TO_PAGES(lh->init_size));
-
   if (!kernel_mem)
-    kernel_mem = grub_efi_allocate_pages_max(0x3fffffff,
+    kernel_mem = grub_efi_allocate_pages_max(GRUB_EFI_MAX_ALLOCATION_ADDRESS,
 					     BYTES_TO_PAGES(lh->init_size));
-
+  if (!kernel_mem)
+    kernel_mem = grub_efi_allocate_pages_max(GRUB_EFI_MAX_USABLE_ADDRESS,
+					     BYTES_TO_PAGES(lh->init_size));
   if (!kernel_mem)
     {
       grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("can't allocate kernel"));

--- a/grub-core/loader/i386/efi/linux.c
+++ b/grub-core/loader/i386/efi/linux.c
@@ -49,6 +49,65 @@ static char *linux_cmdline;
 
 #define BYTES_TO_PAGES(bytes)   (((bytes) + 0xfff) >> 12)
 
+struct allocation_choice {
+    grub_efi_physical_address_t addr;
+    grub_efi_allocate_type_t alloc_type;
+};
+
+static struct allocation_choice max_addresses[] =
+  {
+    { GRUB_EFI_MAX_ALLOCATION_ADDRESS, GRUB_EFI_ALLOCATE_MAX_ADDRESS },
+    { GRUB_EFI_MAX_ALLOCATION_ADDRESS, GRUB_EFI_ALLOCATE_MAX_ADDRESS },
+    { GRUB_EFI_MAX_ALLOCATION_ADDRESS, GRUB_EFI_ALLOCATE_MAX_ADDRESS },
+    { 0, 0 }
+  };
+
+static inline void
+kernel_free(void *addr, grub_efi_uintn_t size)
+{
+  if (addr && size)
+    grub_efi_free_pages ((grub_efi_physical_address_t)(grub_addr_t)addr,
+			 BYTES_TO_PAGES(size));
+}
+
+static void *
+kernel_alloc(grub_efi_uintn_t size, const char * const errmsg)
+{
+  void *addr = 0;
+  unsigned int i;
+  grub_efi_physical_address_t prev_max = 0;
+
+  for (i = 0; max_addresses[i].addr != 0 && addr == 0; i++)
+    {
+      grub_uint64_t max = max_addresses[i].addr;
+      grub_efi_uintn_t pages;
+
+      if (max == prev_max)
+	continue;
+
+      pages = BYTES_TO_PAGES(size);
+      grub_dprintf ("linux", "Trying to allocate %lu pages from %p\n",
+		    pages, (void *)max);
+
+      prev_max = max;
+      addr = grub_efi_allocate_pages_real (max, pages,
+					   max_addresses[i].alloc_type,
+					   GRUB_EFI_LOADER_DATA);
+      if (addr)
+	grub_dprintf ("linux", "Allocated at %p\n", addr);
+    }
+
+  while (grub_error_pop ())
+    {
+      ;
+    }
+
+  if (addr == NULL)
+    grub_error (GRUB_ERR_OUT_OF_MEMORY, "%s", errmsg);
+
+  return addr;
+}
+
 static grub_err_t
 grub_linuxefi_boot (void)
 {
@@ -64,19 +123,12 @@ grub_linuxefi_unload (void)
 {
   grub_dl_unref (my_mod);
   loaded = 0;
-  if (initrd_mem)
-    grub_efi_free_pages ((grub_efi_physical_address_t)(grub_addr_t)initrd_mem,
-			 BYTES_TO_PAGES(params->ramdisk_size));
-  if (linux_cmdline)
-    grub_efi_free_pages ((grub_efi_physical_address_t)(grub_addr_t)
-			 linux_cmdline,
-			 BYTES_TO_PAGES(params->cmdline_size + 1));
-  if (kernel_mem)
-    grub_efi_free_pages ((grub_efi_physical_address_t)(grub_addr_t)kernel_mem,
-			 BYTES_TO_PAGES(kernel_size));
-  if (params)
-    grub_efi_free_pages ((grub_efi_physical_address_t)(grub_addr_t)params,
-			 BYTES_TO_PAGES(16384));
+
+  kernel_free(initrd_mem, params->ramdisk_size);
+  kernel_free(linux_cmdline, params->cmdline_size + 1);
+  kernel_free(kernel_mem, kernel_size);
+  kernel_free(params, sizeof(*params));
+
   return GRUB_ERR_NONE;
 }
 
@@ -157,19 +209,13 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
 	}
     }
 
-  initrd_mem = grub_efi_allocate_pages_max (GRUB_EFI_MAX_ALLOCATION_ADDRESS, BYTES_TO_PAGES(size));
-  if (!initrd_mem)
-    initrd_mem = grub_efi_allocate_pages_max (GRUB_EFI_MAX_USABLE_ADDRESS, BYTES_TO_PAGES(size));
-  if (!initrd_mem)
-    {
-      grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("can't allocate initrd"));
-      goto fail;
-    }
-
-  grub_dprintf ("linux", "initrd_mem = %lx\n", (unsigned long) initrd_mem);
+  initrd_mem = kernel_alloc(size, N_("can't allocate initrd"));
+  if (initrd_mem == NULL)
+    goto fail;
+  grub_dprintf ("linux", "initrd_mem = %p\n", initrd_mem);
 
   params->ramdisk_size = size;
-  params->ramdisk_image = (grub_uint32_t)(grub_addr_t) initrd_mem;
+  params->ramdisk_image = initrd_mem;
 
   ptr = initrd_mem;
 
@@ -230,7 +276,6 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
   filelen = grub_file_size (file);
 
   kernel = grub_malloc(filelen);
-
   if (!kernel)
     {
       grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("cannot allocate kernel buffer"));
@@ -289,7 +334,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
       goto fail;
     }
 
-#if defined(__x86_64__) || defined(__aarch64__)
+#if defined(__x86_64__)
   grub_dprintf ("linux", "checking lh->xloadflags\n");
   if (!(lh->xloadflags & LINUX_XLF_KERNEL_64))
     {
@@ -308,17 +353,9 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
     }
 #endif
 
-  params = grub_efi_allocate_pages_max (GRUB_EFI_MAX_ALLOCATION_ADDRESS,
-					BYTES_TO_PAGES(sizeof(*params)));
+  params = kernel_alloc (sizeof(*params), "cannot allocate kernel parameters");
   if (!params)
-    params = grub_efi_allocate_pages_max (GRUB_EFI_MAX_USABLE_ADDRESS,
-					  BYTES_TO_PAGES(sizeof(*params)));
-  if (! params)
-    {
-      grub_error (GRUB_ERR_OUT_OF_MEMORY, "cannot allocate kernel parameters");
-      goto fail;
-    }
-
+    goto fail;
   grub_dprintf ("linux", "params = %p\n", params);
 
   grub_memset (params, 0, sizeof(*params));
@@ -337,19 +374,10 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
   grub_dprintf ("linux", "new lh is at %p\n", lh);
 
   grub_dprintf ("linux", "setting up cmdline\n");
-  linux_cmdline = grub_efi_allocate_pages_max(GRUB_EFI_MAX_ALLOCATION_ADDRESS,
-					      BYTES_TO_PAGES(lh->cmdline_size + 1));
+  linux_cmdline = kernel_alloc (lh->cmdline_size + 1, N_("can't allocate cmdline"));
   if (!linux_cmdline)
-    linux_cmdline = grub_efi_allocate_pages_max(GRUB_EFI_MAX_USABLE_ADDRESS,
-						BYTES_TO_PAGES(lh->cmdline_size + 1));
-  if (!linux_cmdline)
-    {
-      grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("can't allocate cmdline"));
-      goto fail;
-    }
-
-  grub_dprintf ("linux", "linux_cmdline = %lx\n",
-		(unsigned long)linux_cmdline);
+    goto fail;
+  grub_dprintf ("linux", "linux_cmdline = %p\n", linux_cmdline);
 
   grub_memcpy (linux_cmdline, LINUX_IMAGE, sizeof (LINUX_IMAGE));
   grub_create_loader_cmdline (argc, argv,
@@ -358,27 +386,24 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 			      GRUB_VERIFY_KERNEL_CMDLINE);
 
   grub_dprintf ("linux", "cmdline:%s\n", linux_cmdline);
-  grub_dprintf ("linux", "setting lh->cmd_line_ptr\n");
-  lh->cmd_line_ptr = (grub_uint32_t)(grub_addr_t)linux_cmdline;
+  grub_dprintf ("linux", "setting lh->cmd_line_ptr to 0x%08x\n",
+		linux_cmdline);
+  lh->cmd_line_ptr = linux_cmdline;
 
   handover_offset = lh->handover_offset;
-  grub_dprintf("linux", "handover_offset: %08x\n", handover_offset);
+  grub_dprintf("linux", "handover_offset: 0x%08x\n", handover_offset);
 
   start = (lh->setup_sects + 1) * 512;
 
-  kernel_mem = grub_efi_allocate_pages_max(lh->pref_address,
-					   BYTES_TO_PAGES(lh->init_size));
-  if (!kernel_mem)
-    kernel_mem = grub_efi_allocate_pages_max(GRUB_EFI_MAX_ALLOCATION_ADDRESS,
-					     BYTES_TO_PAGES(lh->init_size));
-  if (!kernel_mem)
-    kernel_mem = grub_efi_allocate_pages_max(GRUB_EFI_MAX_USABLE_ADDRESS,
-					     BYTES_TO_PAGES(lh->init_size));
-  if (!kernel_mem)
+  grub_dprintf ("linux", "lh->pref_address: %p\n", (void *)(grub_addr_t)lh->pref_address);
+  if (lh->pref_address < (grub_uint64_t)GRUB_EFI_MAX_ALLOCATION_ADDRESS)
     {
-      grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("can't allocate kernel"));
-      goto fail;
+      max_addresses[0].addr = lh->pref_address;
+      max_addresses[0].alloc_type = GRUB_EFI_ALLOCATE_ADDRESS;
     }
+  kernel_mem = kernel_alloc (lh->init_size, N_("can't allocate kernel"));
+  if (!kernel_mem)
+    goto fail;
   grub_dprintf("linux", "kernel_mem = %p\n", kernel_mem);
 
   grub_loader_set (grub_linuxefi_boot, grub_linuxefi_unload, 0);
@@ -413,18 +438,14 @@ fail:
       loaded = 0;
     }
 
-  if (linux_cmdline && lh && !loaded)
-    grub_efi_free_pages ((grub_efi_physical_address_t)(grub_addr_t)
-			 linux_cmdline,
-			 BYTES_TO_PAGES(lh->cmdline_size + 1));
+  if (!loaded)
+    {
+      if (lh)
+	kernel_free (linux_cmdline, lh->cmdline_size + 1);
 
-  if (kernel_mem && !loaded)
-    grub_efi_free_pages ((grub_efi_physical_address_t)(grub_addr_t)kernel_mem,
-			 BYTES_TO_PAGES(kernel_size));
-
-  if (params && !loaded)
-    grub_efi_free_pages ((grub_efi_physical_address_t)(grub_addr_t)params,
-			 BYTES_TO_PAGES(16384));
+      kernel_free (kernel_mem, kernel_size);
+      kernel_free (params, sizeof(*params));
+    }
 
   return grub_errno;
 }

--- a/grub-core/loader/i386/efi/linux.c
+++ b/grub-core/loader/i386/efi/linux.c
@@ -258,32 +258,9 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 	}
     }
 
-  params = grub_efi_allocate_pages_max (GRUB_EFI_MAX_ALLOCATION_ADDRESS,
-					BYTES_TO_PAGES(sizeof(*params)));
-  if (!params)
-    params = grub_efi_allocate_pages_max (GRUB_EFI_MAX_USABLE_ADDRESS,
-					  BYTES_TO_PAGES(sizeof(*params)));
-  if (! params)
-    {
-      grub_error (GRUB_ERR_OUT_OF_MEMORY, "cannot allocate kernel parameters");
-      goto fail;
-    }
+  lh = (struct linux_i386_kernel_header *)kernel;
+  grub_dprintf ("linux", "original lh is at %p\n", kernel);
 
-  grub_dprintf ("linux", "params = %p\n", params);
-
-  grub_memset (params, 0, sizeof(*params));
-
-  setup_header_end_offset = *((grub_uint8_t *)kernel + 0x201);
-  grub_dprintf ("linux", "copying %lu bytes from %p to %p\n",
-		MIN((grub_size_t)0x202+setup_header_end_offset,
-		    sizeof (*params)) - 0x1f1,
-		(grub_uint8_t *)kernel + 0x1f1,
-		(grub_uint8_t *)params + 0x1f1);
-  grub_memcpy ((grub_uint8_t *)params + 0x1f1,
-	       (grub_uint8_t *)kernel + 0x1f1,
-		MIN((grub_size_t)0x202+setup_header_end_offset,sizeof (*params)) - 0x1f1);
-  lh = (struct linux_i386_kernel_header *)params;
-  grub_dprintf ("linux", "lh is at %p\n", lh);
   grub_dprintf ("linux", "checking lh->boot_flag\n");
   if (lh->boot_flag != grub_cpu_to_le16 (0xaa55))
     {
@@ -331,6 +308,34 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
     }
 #endif
 
+  params = grub_efi_allocate_pages_max (GRUB_EFI_MAX_ALLOCATION_ADDRESS,
+					BYTES_TO_PAGES(sizeof(*params)));
+  if (!params)
+    params = grub_efi_allocate_pages_max (GRUB_EFI_MAX_USABLE_ADDRESS,
+					  BYTES_TO_PAGES(sizeof(*params)));
+  if (! params)
+    {
+      grub_error (GRUB_ERR_OUT_OF_MEMORY, "cannot allocate kernel parameters");
+      goto fail;
+    }
+
+  grub_dprintf ("linux", "params = %p\n", params);
+
+  grub_memset (params, 0, sizeof(*params));
+
+  setup_header_end_offset = *((grub_uint8_t *)kernel + 0x201);
+  grub_dprintf ("linux", "copying %lu bytes from %p to %p\n",
+		MIN((grub_size_t)0x202+setup_header_end_offset,
+		    sizeof (*params)) - 0x1f1,
+		(grub_uint8_t *)kernel + 0x1f1,
+		(grub_uint8_t *)params + 0x1f1);
+  grub_memcpy ((grub_uint8_t *)params + 0x1f1,
+	       (grub_uint8_t *)kernel + 0x1f1,
+		MIN((grub_size_t)0x202+setup_header_end_offset,sizeof (*params)) - 0x1f1);
+
+  lh = (struct linux_i386_kernel_header *)params;
+  grub_dprintf ("linux", "new lh is at %p\n", lh);
+
   grub_dprintf ("linux", "setting up cmdline\n");
   linux_cmdline = grub_efi_allocate_pages_max(GRUB_EFI_MAX_ALLOCATION_ADDRESS,
 					      BYTES_TO_PAGES(lh->cmdline_size + 1));
@@ -356,8 +361,8 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
   grub_dprintf ("linux", "setting lh->cmd_line_ptr\n");
   lh->cmd_line_ptr = (grub_uint32_t)(grub_addr_t)linux_cmdline;
 
-  grub_dprintf ("linux", "computing handover offset\n");
   handover_offset = lh->handover_offset;
+  grub_dprintf("linux", "handover_offset: %08x\n", handover_offset);
 
   start = (lh->setup_sects + 1) * 512;
 
@@ -374,26 +379,28 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
       grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("can't allocate kernel"));
       goto fail;
     }
-
-  grub_dprintf ("linux", "kernel_mem = %lx\n", (unsigned long) kernel_mem);
+  grub_dprintf("linux", "kernel_mem = %p\n", kernel_mem);
 
   grub_loader_set (grub_linuxefi_boot, grub_linuxefi_unload, 0);
-  loaded=1;
+
+  loaded = 1;
+
   grub_dprintf ("linux", "setting lh->code32_start to %p\n", kernel_mem);
   lh->code32_start = (grub_uint32_t)(grub_addr_t) kernel_mem;
 
   grub_memcpy (kernel_mem, (char *)kernel + start, filelen - start);
 
-  grub_dprintf ("linux", "setting lh->type_of_loader\n");
   lh->type_of_loader = 0x6;
+  grub_dprintf ("linux", "setting lh->type_of_loader = 0x%02x\n",
+		lh->type_of_loader);
 
-  grub_dprintf ("linux", "setting lh->ext_loader_{type,ver}\n");
   params->ext_loader_type = 0;
   params->ext_loader_ver = 2;
-  grub_dprintf("linux", "kernel_mem: %p handover_offset: %08x\n",
-	       kernel_mem, handover_offset);
+  grub_dprintf ("linux",
+		"setting lh->ext_loader_{type,ver} = {0x%02x,0x%02x}\n",
+		params->ext_loader_type, params->ext_loader_ver);
 
- fail:
+fail:
   if (file)
     grub_file_close (file);
 

--- a/grub-core/loader/i386/efi/linux.c
+++ b/grub-core/loader/i386/efi/linux.c
@@ -146,7 +146,7 @@ grub_linuxefi_unload (void)
   return GRUB_ERR_NONE;
 }
 
-#define BOUNCE_BUFFER_MAX 0x10000000ull
+#define BOUNCE_BUFFER_MAX 0x1000000ull
 
 static grub_ssize_t
 read(grub_file_t file, grub_uint8_t *bufp, grub_size_t len)

--- a/include/grub/arm/efi/memory.h
+++ b/include/grub/arm/efi/memory.h
@@ -2,5 +2,6 @@
 #include <grub/efi/memory.h>
 
 #define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffff
+#define GRUB_EFI_MAX_ALLOCATION_ADDRESS GRUB_EFI_MAX_USABLE_ADDRESS
 
 #endif /* ! GRUB_MEMORY_CPU_HEADER */

--- a/include/grub/arm64/efi/memory.h
+++ b/include/grub/arm64/efi/memory.h
@@ -2,5 +2,6 @@
 #include <grub/efi/memory.h>
 
 #define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffffffffULL
+#define GRUB_EFI_MAX_ALLOCATION_ADDRESS GRUB_EFI_MAX_USABLE_ADDRESS
 
 #endif /* ! GRUB_MEMORY_CPU_HEADER */

--- a/include/grub/efi/disk.h
+++ b/include/grub/efi/disk.h
@@ -27,6 +27,8 @@ grub_efi_handle_t
 EXPORT_FUNC(grub_efidisk_get_device_handle) (grub_disk_t disk);
 char *EXPORT_FUNC(grub_efidisk_get_device_name) (grub_efi_handle_t *handle);
 
+void EXPORT_FUNC(grub_efidisk_reenumerate_disks) (void);
+
 void grub_efidisk_init (void);
 void grub_efidisk_fini (void);
 

--- a/include/grub/efi/efi.h
+++ b/include/grub/efi/efi.h
@@ -36,6 +36,11 @@ EXPORT_FUNC(grub_efi_locate_handle) (grub_efi_locate_search_type_t search_type,
 				     grub_efi_guid_t *protocol,
 				     void *search_key,
 				     grub_efi_uintn_t *num_handles);
+grub_efi_status_t
+EXPORT_FUNC(grub_efi_connect_controller) (grub_efi_handle_t controller_handle,
+					  grub_efi_handle_t *driver_image_handle,
+					  grub_efi_device_path_protocol_t *remaining_device_path,
+					  grub_efi_boolean_t recursive);
 void *EXPORT_FUNC(grub_efi_open_protocol) (grub_efi_handle_t handle,
 					   grub_efi_guid_t *protocol,
 					   grub_efi_uint32_t attributes);

--- a/include/grub/i386/efi/memory.h
+++ b/include/grub/i386/efi/memory.h
@@ -2,5 +2,6 @@
 #include <grub/efi/memory.h>
 
 #define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffff
+#define GRUB_EFI_MAX_ALLOCATION_ADDRESS GRUB_EFI_MAX_USABLE_ADDRESS
 
 #endif /* ! GRUB_MEMORY_CPU_HEADER */

--- a/include/grub/i386/linux.h
+++ b/include/grub/i386/linux.h
@@ -230,7 +230,11 @@ struct linux_kernel_params
   grub_uint32_t ofw_cif_handler;	/* b8 */
   grub_uint32_t ofw_idt;		/* bc */
 
-  grub_uint8_t padding7[0x1b8 - 0xc0];
+  grub_uint32_t ext_ramdisk_image;	/* 0xc0 */
+  grub_uint32_t ext_ramdisk_size;	/* 0xc4 */
+  grub_uint32_t ext_cmd_line_ptr;	/* 0xc8 */
+
+  grub_uint8_t padding7[0x1b8 - 0xcc];
 
   union
     {

--- a/include/grub/ia64/efi/memory.h
+++ b/include/grub/ia64/efi/memory.h
@@ -2,5 +2,6 @@
 #include <grub/efi/memory.h>
 
 #define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffff
+#define GRUB_EFI_MAX_ALLOCATION_ADDRESS GRUB_EFI_MAX_USABLE_ADDRESS
 
 #endif /* ! GRUB_MEMORY_CPU_HEADER */

--- a/include/grub/search.h
+++ b/include/grub/search.h
@@ -19,11 +19,20 @@
 #ifndef GRUB_SEARCH_HEADER
 #define GRUB_SEARCH_HEADER 1
 
-void grub_search_fs_file (const char *key, const char *var, int no_floppy,
+enum search_flags
+  {
+    SEARCH_FLAGS_NO_FLOPPY	= 1,
+    SEARCH_FLAGS_EFIDISK_ONLY	= 2
+  };
+
+void grub_search_fs_file (const char *key, const char *var,
+			  enum search_flags flags,
 			  char **hints, unsigned nhints);
-void grub_search_fs_uuid (const char *key, const char *var, int no_floppy,
+void grub_search_fs_uuid (const char *key, const char *var,
+			  enum search_flags flags,
 			  char **hints, unsigned nhints);
-void grub_search_label (const char *key, const char *var, int no_floppy,
+void grub_search_label (const char *key, const char *var,
+			enum search_flags flags,
 			char **hints, unsigned nhints);
 
 #endif

--- a/include/grub/x86_64/efi/memory.h
+++ b/include/grub/x86_64/efi/memory.h
@@ -2,9 +2,11 @@
 #include <grub/efi/memory.h>
 
 #if defined (__code_model_large__)
-#define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffff
+#define GRUB_EFI_MAX_USABLE_ADDRESS __UINTPTR_MAX__
+#define GRUB_EFI_MAX_ALLOCATION_ADDRESS 0x7fffffff
 #else
 #define GRUB_EFI_MAX_USABLE_ADDRESS 0x7fffffff
+#define GRUB_EFI_MAX_ALLOCATION_ADDRESS GRUB_EFI_MAX_USABLE_ADDRESS
 #endif
 
 #endif /* ! GRUB_MEMORY_CPU_HEADER */


### PR DESCRIPTION
x86-efi: Backport rhel 9.0 support for loading initrd above 4 GB to rhel 8.6

This pull request cherry picks the following RHEL 9.0.0 commits into RHEL 8.6.0:

9035d4f9e Try to pick better locations for kernel and initrd
7765a790d x86-efi: Use bounce buffers for reading to addresses > 4GB
486cdd488 x86-efi: Re-arrange grub_cmd_linux() a little bit.
cfea4ae78 x86-efi: Make our own allocator for kernel stuff
2b6369670 x86-efi: Allow initrd+params+cmdline allocations above 4GB.
1c0d2ebdd x86-efi: Reduce maximum bounce buffer size to 16 MiB

As noted in the individual commit logs, two patches had minor conflicts.

This pull request resolves rhbz#2048433.

Some methods of installing the Openshift Container Platform (OCP) control plane software rely on grubx64.efi to load a very large initrd. The system firmware on some platforms does not leave sufficient contiguous free pages for such a large initrd unless it is loaded above 4 GB. This backport from rhel 9.0.0 enables grubx64.efi to load an initrd into memory above 4 GB from its prior limit of 1 GB.