### PR TITLE
Fedora 37 do not verify kernel twice

### DIFF
--- a/grub-core/loader/arm64/linux.c
+++ b/grub-core/loader/arm64/linux.c
@@ -34,7 +34,6 @@
 #include <grub/i18n.h>
 #include <grub/lib/cmdline.h>
 #include <grub/verify.h>
-#include <grub/efi/sb.h>
 
 GRUB_MOD_LICENSE ("GPLv3+");
 
@@ -341,7 +340,6 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
   grub_off_t filelen;
   grub_uint32_t align;
   void *kernel = NULL;
-  int rc;
 
   grub_dl_ref (my_mod);
 
@@ -368,17 +366,6 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
       grub_error (GRUB_ERR_FILE_READ_ERROR, N_("Can't read kernel %s"),
 		  argv[0]);
       goto fail;
-    }
-
-  if (grub_efi_get_secureboot () == GRUB_EFI_SECUREBOOT_MODE_ENABLED)
-    {
-      rc = grub_linuxefi_secure_validate (kernel, filelen);
-      if (rc <= 0)
-	{
-	  grub_error (GRUB_ERR_INVALID_COMMAND,
-		      N_("%s has invalid signature"), argv[0]);
-	  goto fail;
-	}
     }
 
   if (grub_arch_efi_linux_check_image (kernel) != GRUB_ERR_NONE)

--- a/grub-core/loader/efi/chainloader.c
+++ b/grub-core/loader/efi/chainloader.c
@@ -906,7 +906,6 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
   grub_efi_device_path_t *dp = 0;
   char *filename;
   void *boot_image = 0;
-  int rc;
 
   if (argc == 0)
     return grub_error (GRUB_ERR_BAD_ARGUMENT, N_("filename expected"));
@@ -1082,9 +1081,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
       orig_dev = 0;
     }
 
-  rc = grub_linuxefi_secure_validate((void *)(unsigned long)address, fsize);
-  grub_dprintf ("chain", "linuxefi_secure_validate: %d\n", rc);
-  if (rc > 0)
+  if (grub_efi_get_secureboot () == GRUB_EFI_SECUREBOOT_MODE_ENABLED)
     {
       grub_file_close (file);
       grub_device_close (dev);
@@ -1092,7 +1089,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
 		       grub_secureboot_chainloader_unload, 0);
       return 0;
     }
-  else if (rc == 0)
+  else
     {
       grub_load_and_start_image(boot_image);
       grub_file_close (file);
@@ -1101,7 +1098,6 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
 
       return 0;
     }
-  // -1 fall-through to fail
 
 fail:
   if (orig_dev)

--- a/grub-core/loader/efi/linux.c
+++ b/grub-core/loader/efi/linux.c
@@ -24,46 +24,6 @@
 #include <grub/efi/pe32.h>
 #include <grub/efi/linux.h>
 
-#define SHIM_LOCK_GUID \
- { 0x605dab50, 0xe046, 0x4300, {0xab, 0xb6, 0x3d, 0xd8, 0x10, 0xdd, 0x8b, 0x23} }
-
-struct grub_efi_shim_lock
-{
-  grub_efi_status_t (*verify) (void *buffer, grub_uint32_t size);
-};
-typedef struct grub_efi_shim_lock grub_efi_shim_lock_t;
-
-// Returns 1 on success, -1 on error, 0 when not available
-int
-grub_linuxefi_secure_validate (void *data, grub_uint32_t size)
-{
-  grub_efi_guid_t guid = SHIM_LOCK_GUID;
-  grub_efi_shim_lock_t *shim_lock;
-  grub_efi_status_t status;
-
-  shim_lock = grub_efi_locate_protocol(&guid, NULL);
-  grub_dprintf ("secureboot", "shim_lock: %p\n", shim_lock);
-  if (!shim_lock)
-    {
-      grub_dprintf ("secureboot", "shim not available\n");
-      return 0;
-    }
-
-  grub_dprintf ("secureboot", "Asking shim to verify kernel signature\n");
-  status = shim_lock->verify (data, size);
-  grub_dprintf ("secureboot", "shim_lock->verify(): %ld\n", (long int)status);
-  if (status == GRUB_EFI_SUCCESS)
-    {
-      grub_dprintf ("secureboot", "Kernel signature verification passed\n");
-      return 1;
-    }
-
-  grub_dprintf ("secureboot", "Kernel signature verification failed (0x%lx)\n",
-		(unsigned long) status);
-
-  return -1;
-}
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align"
 

--- a/grub-core/loader/i386/efi/linux.c
+++ b/grub-core/loader/i386/efi/linux.c
@@ -30,7 +30,6 @@
 #include <grub/cpu/efi/memory.h>
 #include <grub/tpm.h>
 #include <grub/safemath.h>
-#include <grub/efi/sb.h>
 
 GRUB_MOD_LICENSE ("GPLv3+");
 
@@ -278,7 +277,6 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
   grub_ssize_t start, filelen;
   void *kernel = NULL;
   int setup_header_end_offset;
-  int rc;
 
   grub_dl_ref (my_mod);
 
@@ -306,17 +304,6 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
       grub_error (GRUB_ERR_FILE_READ_ERROR, N_("Can't read kernel %s"),
 		  argv[0]);
       goto fail;
-    }
-
-  if (grub_efi_get_secureboot () == GRUB_EFI_SECUREBOOT_MODE_ENABLED)
-    {
-      rc = grub_linuxefi_secure_validate (kernel, filelen);
-      if (rc <= 0)
-	{
-	  grub_error (GRUB_ERR_INVALID_COMMAND,
-		      N_("%s has invalid signature"), argv[0]);
-	  goto fail;
-	}
     }
 
   lh = (struct linux_i386_kernel_header *)kernel;

--- a/include/grub/efi/linux.h
+++ b/include/grub/efi/linux.h
@@ -22,8 +22,6 @@
 #include <grub/err.h>
 #include <grub/symbol.h>
 
-int
-EXPORT_FUNC(grub_linuxefi_secure_validate) (void *data, grub_uint32_t size);
 grub_err_t
 EXPORT_FUNC(grub_efi_linux_boot) (void *kernel_address, grub_off_t offset,
 				  void *kernel_param);


### PR DESCRIPTION
grub2.06 codebase has shim-lock-verifier as built-in and active when secureboot is on.

this results in tpm measurements performed upon grub_file_open(), as it calls shim protocol verify API.

in addition to that tpm measurement, the pre-grub-2.06 linuxefi patches were also calling shim protocol verify API against the same file when booting, or chainloading.

this results in duplicate PCR 4 measurements from shim, which break compatibility with existing sealings upon grub2.04+linuxefi-patches to grub2.06+linuxefi-patches like so:

Unexpected
```
 9 6e2b21deab0c455bbb8585ee01617d77f4404ea5 EV_IPL [ (hd0,gpt3)/EFI/ubuntu/kernel.efi ]
 4 2a198382f64fbf5d8ef3eb6f83e1c5dcd52922dd EV_EFI_BOOT_SERVICES_APPLICATION [ Invalid event data: event data smaller than expected ]
 4 2a198382f64fbf5d8ef3eb6f83e1c5dcd52922dd EV_EFI_BOOT_SERVICES_APPLICATION [ Invalid event data: event data smaller than expected ]
```

Expected
```
 9 6e2b21deab0c455bbb8585ee01617d77f4404ea5 EV_IPL [ (hd0,gpt3)/EFI/ubuntu/kernel.efi ]
 4 2a198382f64fbf5d8ef3eb6f83e1c5dcd52922dd EV_EFI_BOOT_SERVICES_APPLICATION [ Invalid event data: event data smaller than expected ]
```

Above are measurements parsed with https://github.com/canonical/tcglog-parser/tree/master/tcglog-dump when grub is chainloading a BSP type 2 binary. https://systemd.io/BOOT_LOADER_SPECIFICATION/
Similar results of duplicate measurements of vmlinuz when doing a "normal" boot.

These manual calls to shim protocol api are now redundant with the shim-lock-verifier, as the code path leading up to _validate() call is now only reached after shim protocol successfully verifies the binary in question. But it does generate a duplicate TPM measurement and wastes boot time.

This patch removes these duplicate code paths for i386, arm64, and chainloader boots, and thus removing all usage of the manual _validate() codepath.

These patches must only be used on codebases that have shim-lock-verifier as built-in, i.e. grub-2.06 vanilla releases. Nobody should take these patches to older grub codebases which do not have verifiers framework, or shim-lock-verifier is not builtin.

This bug was discovered upon testing Ubuntu's upgrade from 2.04+linuxefi to 2.06+linuxefi.

This is tested on amd64 linuxefi loader; and chainloader.
arm64 linuxefi loader untested, but it is the same codepaths as amd64 validated by inspection.