### PR TITLE
arm64: Use proper memory type for kernel allocation

### DIFF
--- a/grub-core/loader/arm64/linux.c
+++ b/grub-core/loader/arm64/linux.c
@@ -26,7 +26,9 @@
 #include <grub/mm.h>
 #include <grub/types.h>
 #include <grub/cpu/linux.h>
+#include <grub/efi/api.h>
 #include <grub/efi/efi.h>
+#include <grub/cpu/efi/memory.h>
 #include <grub/efi/fdtload.h>
 #include <grub/efi/memory.h>
 #include <grub/efi/linux.h>
@@ -403,7 +405,10 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
   grub_loader_unset();
 
   kernel_alloc_pages = GRUB_EFI_BYTES_TO_PAGES (kernel_size + align - 1);
-  kernel_alloc_addr = grub_efi_allocate_any_pages (kernel_alloc_pages);
+  kernel_alloc_addr = grub_efi_allocate_pages_real (GRUB_EFI_MAX_USABLE_ADDRESS,
+						    kernel_alloc_pages,
+						    GRUB_EFI_ALLOCATE_MAX_ADDRESS,
+						    GRUB_EFI_LOADER_CODE);
   grub_dprintf ("linux", "kernel numpages: %d\n", kernel_alloc_pages);
   if (!kernel_alloc_addr)
     {


### PR DESCRIPTION
Currently, the kernel pages are allocated with type EFI_LOADER_DATA.
While the vast majority of systems will happily execute code from those
pages (i.e. don't care about memory protection), the Microsoft Surface
Pro X stalls, as this memory is not designated as "executable".

Therefore, allocate the kernel pages as EFI_LOADER_CODE to request
memory that is actually executable.

Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>