### PR TITLE
Try reserving less ram...

### DIFF
--- a/grub-core/kern/efi/mm.c
+++ b/grub-core/kern/efi/mm.c
@@ -740,7 +740,7 @@ grub_efi_mm_init (void)
   /* By default, request three quarters of the available memory.  */
   total_pages = get_total_pages (filtered_memory_map, desc_size,
 				 filtered_memory_map_end);
-  required_pages = (total_pages >> 1) + (total_pages >> 2);
+  required_pages = (total_pages >> 1);
   if (required_pages < BYTES_TO_PAGES (MIN_HEAP_SIZE))
     required_pages = BYTES_TO_PAGES (MIN_HEAP_SIZE);
   else if (required_pages > BYTES_TO_PAGES (MAX_HEAP_SIZE))

--- a/util/grub.d/10_linux.in
+++ b/util/grub.d/10_linux.in
@@ -161,6 +161,12 @@ update_bls_cmdline()
     local cmdline="root=${LINUX_ROOT_DEVICE} ro ${GRUB_CMDLINE_LINUX} ${GRUB_CMDLINE_LINUX_DEFAULT}"
     local -a files=($(get_sorted_bls))
 
+    if [[ ! -f /etc/kernel/cmdline ]]; then
+	# anaconda has the correct information to do this during install;
+	# afterward, grubby will take care of syncing on updates.
+	echo "$cmdline rhgb quiet" > /etc/kernel/cmdline
+    fi
+
     for bls in "${files[@]}"; do
         local options="${cmdline}"
         if [ -z "${bls##*debug*}" ]; then


### PR DESCRIPTION
In 005a0aaaad2a00a1fa1e60d94cc4fd5407c22e7d, we switched from reserving
one quarter of the available free memory to three quarters.  Apparently
this has some unfortunate side-affects for some workloads, and has
negatively effected chainloading[0] as well as Fedora CoreOS[1].

This patch changes it to reserve /half/ of available memory, in hopes
that this is a working compromise.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=2115202
[1] https://github.com/coreos/fedora-coreos-tracker/issues/1271

Signed-off-by: Peter Jones <pjones@redhat.com>