### PR TITLE
Optimized Statement Format

### DIFF
--- a/grub-core/fs/zfs/zfs_fletcher.c
+++ b/grub-core/fs/zfs/zfs_fletcher.c
@@ -70,7 +70,7 @@ fletcher_4 (const void *buf, grub_uint64_t size, grub_zfs_endian_t endian,
   
   for (a = b = c = d = 0; ip < ipend; ip++) 
     {
-      a += grub_zfs_to_cpu32 (ip[0], endian);;
+      a += grub_zfs_to_cpu32 (ip[0], endian);
       b += a;
       c += b;
       d += c;

--- a/grub-core/lib/legacy_parse.c
+++ b/grub-core/lib/legacy_parse.c
@@ -405,7 +405,7 @@ adjust_file (const char *in, grub_size_t len)
       if (!ret)
 	return NULL;
 
-      outptr = grub_stpcpy (ret, "(tftp)");;
+      outptr = grub_stpcpy (ret, "(tftp)");
       for (ptr = rest; ptr < in + len; ptr++)
 	{
 	  if (*ptr == '\'' || *ptr == '\\')

--- a/grub-core/lib/libgcrypt/cipher/des.c
+++ b/grub-core/lib/libgcrypt/cipher/des.c
@@ -973,7 +973,7 @@ selftest (void)
 
         tripledes_ecb_decrypt (des3, testdata[i].cipher, result);
         if (memcmp (testdata[i].plain, result, 8))
-          return  "Triple-DES SSLeay test failed on decryption.";;
+          return  "Triple-DES SSLeay test failed on decryption.";
       }
   }
 

--- a/grub-core/lib/libgcrypt/cipher/pubkey.c
+++ b/grub-core/lib/libgcrypt/cipher/pubkey.c
@@ -85,7 +85,7 @@ static struct pubkey_table_entry
 static gcry_module_t pubkeys_registered;
 
 /* This is the lock protecting PUBKEYS_REGISTERED.  */
-static ath_mutex_t pubkeys_registered_lock = ATH_MUTEX_INITIALIZER;;
+static ath_mutex_t pubkeys_registered_lock = ATH_MUTEX_INITIALIZER;
 
 /* Flag to check whether the default pubkeys have already been
    registered.  */


### PR DESCRIPTION
Remove an extra semicolon at the end of the statement.