### PR TITLE
arm64/loader: Tweak the loaded kernel size to correct BSS, backport removal of magic number check.

### DIFF
--- a/grub-core/loader/arm64/linux.c
+++ b/grub-core/loader/arm64/linux.c
@@ -316,10 +316,12 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
 static grub_err_t
 parse_pe_header (void *kernel, grub_uint64_t *total_size,
 		 grub_uint32_t *entry_offset,
-		 grub_uint32_t *alignment)
+		 grub_uint32_t *alignment,grub_uint32_t *code_size)
 {
   struct linux_arch_kernel_header *lh = kernel;
   struct grub_armxx_linux_pe_header *pe;
+  grub_uint16_t i;
+  struct grub_pe32_section_table *sections;
 
   pe = (void *)((unsigned long)kernel + lh->hdr_offset);
 
@@ -329,6 +331,19 @@ parse_pe_header (void *kernel, grub_uint64_t *total_size,
   *total_size   = pe->opt.image_size;
   *entry_offset = pe->opt.entry_addr;
   *alignment    = pe->opt.section_alignment;
+  *code_size    = pe->opt.section_alignment;
+
+  sections = (struct grub_pe32_section_table *) ((char *)&pe->opt +
+						 pe->coff.optional_header_size);
+  grub_dprintf ("linux", "num_sections     : %d\n",  pe->coff.num_sections );
+  for (i = 0 ; i < pe->coff.num_sections; i++)
+    {
+      grub_dprintf ("linux", "raw_size   : %lld\n",
+		    (long long) sections[i].raw_data_size);
+      grub_dprintf ("linux", "virt_size  : %lld\n",
+		    (long long) sections[i].virtual_size);
+      *code_size += sections[i].raw_data_size;
+    }
 
   return GRUB_ERR_NONE;
 }
@@ -341,6 +356,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
   grub_err_t err;
   grub_off_t filelen;
   grub_uint32_t align;
+  grub_uint32_t code_size;
   void *kernel = NULL;
   int nx_supported = 1;
 
@@ -373,11 +389,12 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 
   if (grub_arch_efi_linux_check_image (kernel) != GRUB_ERR_NONE)
     goto fail;
-  if (parse_pe_header (kernel, &kernel_size, &handover_offset, &align) != GRUB_ERR_NONE)
+  if (parse_pe_header (kernel, &kernel_size, &handover_offset, &align, &code_size) != GRUB_ERR_NONE)
     goto fail;
   grub_dprintf ("linux", "kernel mem size     : %lld\n", (long long) kernel_size);
   grub_dprintf ("linux", "kernel entry offset : %d\n", handover_offset);
   grub_dprintf ("linux", "kernel alignment    : 0x%x\n", align);
+  grub_dprintf ("linux", "kernel size         : 0x%x\n", code_size);
 
   err = grub_efi_check_nx_image_support((grub_addr_t)kernel, filelen, &nx_supported);
   if (err != GRUB_ERR_NONE)
@@ -396,9 +413,9 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
   kernel_addr = (void *)ALIGN_UP((grub_uint64_t)kernel_alloc_addr, align);
 
   grub_dprintf ("linux", "kernel @ %p\n", kernel_addr);
-  grub_memcpy (kernel_addr, kernel, grub_min(filelen, kernel_size));
-  if (kernel_size > filelen)
-    grub_memset ((char *)kernel_addr + filelen, 0, kernel_size - filelen);
+  grub_memcpy (kernel_addr, kernel, grub_min(code_size, kernel_size));
+  if (kernel_size > code_size)
+    grub_memset ((char *)kernel_addr + code_size, 0, kernel_size - code_size);
   grub_free(kernel);
   kernel = NULL;
 

--- a/grub-core/loader/arm64/linux.c
+++ b/grub-core/loader/arm64/linux.c
@@ -55,9 +55,6 @@ static grub_addr_t initrd_end;
 grub_err_t
 grub_arch_efi_linux_check_image (struct linux_arch_kernel_header * lh)
 {
-  if (lh->magic != GRUB_LINUX_ARMXX_MAGIC_SIGNATURE)
-    return grub_error(GRUB_ERR_BAD_OS, "invalid magic number");
-
   if ((lh->code0 & 0xffff) != GRUB_DOS_MAGIC)
     return grub_error (GRUB_ERR_NOT_IMPLEMENTED_YET,
 		       N_("plain image kernel not supported - rebuild with CONFIG_(U)EFI_STUB enabled"));


### PR DESCRIPTION
The arm64 grub loader code has diverged significantly from the
upstream grub code, which uses boot services to load and start
the EFI stubbed kernel.

This is a bit of a problem, but the larger problem
is that the RH/grub implementation is very simplistic and doesn't
parse much of the PE/COFF header and place the segments in memory
as the PE sections dictate. Instead, there is a rough assumption
that the filesize = text+data and that the difference between that
and the imagesize in the header is BSS. And this fails if the
raw size != virtual size, or there is additional file padding,
etc.

So, we have been getting away with this until the EFI stub
decompressor patches, currently posted, wrap a compressed/signed
EFI + kernel image with a stub decompressor and a signature.

In that case, the BSS data isn't all being cleared properly, so
further, hack this up a bit and compute the on-disk data size
from the section data info rather than its actual disk size.

Finally, we also pick Ard's patch, which drops the magic number
check as it no longer works either.