### PR TITLE
Fix -Wsign-compare warning for GCC 13

### DIFF
--- a/grub-core/net/http.c
+++ b/grub-core/net/http.c
@@ -31,10 +31,10 @@ GRUB_MOD_LICENSE ("GPLv3+");
 
 enum
   {
-    HTTP_PORT = 80,
-    HTTP_MAX_CHUNK_SIZE = 0x80000000
+    HTTP_PORT = 80
   };
 
+#define HTTP_MAX_CHUNK_SIZE 0x80000000
 
 typedef struct http_data
 {


### PR DESCRIPTION
Since GCC 13, when an enum valud is our to int-type range, then all enum values are promoted to the type. Thus, one gets the following warning for HTTP_PORT value:

`grub-core/net/http.c:414:48: error: operand of '?:' changes signedness from 'int' to 'enum <anonymous>' due to unsignedness of other operand [-Werror=sign-compare]`