### PR TITLE
Add basic support for the Boot Loader Interface

### DIFF
--- a/grub-core/Makefile.core.def
+++ b/grub-core/Makefile.core.def
@@ -2611,6 +2611,12 @@ module = {
 };
 
 module = {
+  name = boot-loader-interface;
+  efi = commands/boot-loader-interface.c;
+  enable = efi;
+};
+
+module = {
   name = asn1;
   common = lib/libtasn1/lib/decoding.c;
   common = lib/libtasn1/lib/coding.c;

--- a/grub-core/commands/boot-loader-interface.c
+++ b/grub-core/commands/boot-loader-interface.c
@@ -1,0 +1,216 @@
+/*-*- Mode: C; c-basic-offset: 2; indent-tabs-mode: t -*-*/
+
+/* boot-loader-interface.c - implementation of the boot loader interface
+ */
+
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *
+ *  GRUB is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  GRUB is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <grub/charset.h>
+#include <grub/efi/api.h>
+#include <grub/efi/disk.h>
+#include <grub/efi/efi.h>
+#include <grub/err.h>
+#include <grub/extcmd.h>
+#include <grub/gpt_partition.h>
+#include <grub/misc.h>
+#include <grub/mm.h>
+#include <grub/partition.h>
+
+GRUB_MOD_LICENSE ("GPLv3+");
+
+#define MODNAME "boot-loader-interface"
+
+static const grub_efi_guid_t boot_loader_interface_vendor_guid =
+  { 0x4a67b082, 0x0a4c, 0x41cf,
+    {0xb6, 0xc7, 0x44, 0x0b, 0x29, 0xbb, 0x8c, 0x4f} };
+
+static char *
+machine_get_bootdevice (void)
+{
+  grub_efi_loaded_image_t *image;
+
+  image = grub_efi_get_loaded_image (grub_efi_image_handle);
+  if (!image)
+    return NULL;
+
+  return grub_efidisk_get_device_name (image->device_handle);
+}
+
+static grub_err_t
+get_part_uuid (grub_device_t dev, char **part_uuid)
+{
+  grub_err_t status = GRUB_ERR_NONE;
+  grub_disk_t disk;
+  struct grub_gpt_partentry entry;
+  grub_gpt_part_guid_t *guid;
+
+  if (!dev || !dev->disk || !dev->disk->partition)
+    return grub_error (GRUB_ERR_BAD_ARGUMENT, N_("invalid device"));
+
+  disk = grub_disk_open (dev->disk->name);
+  if (!disk)
+    {
+      status = grub_errno;
+      grub_dprintf (MODNAME, "Error opening disk\n");
+      return grub_errno;
+    }
+
+  if (grub_strcmp (dev->disk->partition->partmap->name, "gpt") != 0)
+    {
+      status = grub_error (GRUB_ERR_BAD_PART_TABLE,
+                           N_("This is not a GPT partition table"));
+      goto finish;
+    }
+
+  if (grub_disk_read (disk, dev->disk->partition->offset,
+                      dev->disk->partition->index, sizeof (entry), &entry))
+    {
+      status = grub_errno;
+      grub_dprintf (MODNAME, "%s: Read error\n", dev->disk->name);
+      goto finish;
+    }
+
+  guid = &entry.guid;
+  *part_uuid = grub_xasprintf (
+      "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+      grub_le_to_cpu32 (guid->data1), grub_le_to_cpu16 (guid->data2),
+      grub_le_to_cpu16 (guid->data3), guid->data4[0], guid->data4[1],
+      guid->data4[2], guid->data4[3], guid->data4[4], guid->data4[5],
+      guid->data4[6], guid->data4[7]);
+  if (!*part_uuid)
+    {
+      status = grub_errno;
+    }
+
+finish:
+  grub_disk_close (disk);
+
+  return status;
+}
+
+static grub_err_t
+set_efi_str_variable (const char *name, const grub_efi_guid_t *guid,
+                      const char *value)
+{
+  grub_size_t len;
+  grub_size_t len16;
+  grub_efi_char16_t *value_16;
+  grub_err_t status;
+
+  len = grub_strlen (value);
+  len16 = len * GRUB_MAX_UTF16_PER_UTF8;
+
+  value_16 = grub_calloc (len16 + 1, sizeof (value_16[0]));
+  if (!value_16)
+    return grub_errno;
+
+  len16
+      = grub_utf8_to_utf16 (value_16, len16, (grub_uint8_t *)value, len, NULL);
+  value_16[len16] = 0;
+
+  status = grub_efi_set_variable_with_attributes (
+      name, guid, (void *)value_16, (len16 + 1) * sizeof (value_16[0]),
+      GRUB_EFI_VARIABLE_BOOTSERVICE_ACCESS | GRUB_EFI_VARIABLE_RUNTIME_ACCESS);
+  if (status != GRUB_ERR_NONE)
+    {
+      grub_dprintf (MODNAME, "Error setting EFI variable %s: %d\n", name,
+                    status);
+    }
+
+  grub_free (value_16);
+
+  return status;
+}
+
+static grub_err_t
+set_loader_info (void)
+{
+  grub_err_t status;
+  status = set_efi_str_variable (
+      "LoaderInfo", &boot_loader_interface_vendor_guid, PACKAGE_STRING);
+  return status;
+}
+
+static grub_err_t
+set_loader_device_part_uuid (void)
+{
+  grub_err_t status = GRUB_ERR_NONE;
+  char *device_name = NULL;
+  grub_device_t device;
+  char *part_uuid = NULL;
+
+  device_name = machine_get_bootdevice ();
+  if (!device_name)
+    {
+      return grub_error (GRUB_ERR_BAD_DEVICE,
+                         N_("Unable to find boot device"));
+    }
+
+  device = grub_device_open (device_name);
+  if (!device)
+    {
+      status = grub_errno;
+      grub_dprintf (MODNAME, "Error opening device: %s", device_name);
+      goto err;
+    }
+
+  status = get_part_uuid (device, &part_uuid);
+
+  grub_device_close (device);
+
+  if (status == GRUB_ERR_NONE)
+    {
+      status = set_efi_str_variable ("LoaderDevicePartUUID",
+                                     &boot_loader_interface_vendor_guid,
+                                     part_uuid);
+    }
+
+err:
+  grub_free (part_uuid);
+  grub_free (device_name);
+  return status;
+}
+
+static grub_err_t
+grub_cmd_boot_loader_interface (grub_extcmd_context_t ctxt UNUSED,
+                                int argc UNUSED, char **args UNUSED)
+{
+  grub_err_t status;
+
+  status = set_loader_info ();
+  if (status != GRUB_ERR_NONE)
+    return status;
+
+  status = set_loader_device_part_uuid ();
+  if (status != GRUB_ERR_NONE)
+    return status;
+
+  return GRUB_ERR_NONE;
+}
+
+static grub_extcmd_t cmd;
+
+GRUB_MOD_INIT (boot-loader-interface)
+{
+  grub_dprintf (MODNAME, "%s got here\n", __func__);
+  cmd = grub_register_extcmd (
+      "boot-loader-interface", grub_cmd_boot_loader_interface, 0, NULL,
+      N_("Set EFI variables according to Boot Loader Interface spec."), NULL);
+}
+
+GRUB_MOD_FINI (boot-loader-interface) { grub_unregister_extcmd (cmd); }

--- a/grub-core/kern/efi/efi.c
+++ b/grub-core/kern/efi/efi.c
@@ -211,8 +211,8 @@ grub_efi_set_virtual_address_map (grub_efi_uintn_t memory_map_size,
 }
 
 grub_err_t
-grub_efi_set_variable(const char *var, const grub_efi_guid_t *guid,
-		      void *data, grub_size_t datasize)
+grub_efi_set_variable_with_attributes(const char *var, const grub_efi_guid_t *guid,
+		      void *data, grub_size_t datasize, grub_uint32_t attributes)
 {
   grub_efi_status_t status;
   grub_efi_runtime_services_t *r;
@@ -229,10 +229,7 @@ grub_efi_set_variable(const char *var, const grub_efi_guid_t *guid,
 
   r = grub_efi_system_table->runtime_services;
 
-  status = efi_call_5 (r->set_variable, var16, guid, 
-		       (GRUB_EFI_VARIABLE_NON_VOLATILE
-			| GRUB_EFI_VARIABLE_BOOTSERVICE_ACCESS
-			| GRUB_EFI_VARIABLE_RUNTIME_ACCESS),
+  status = efi_call_5 (r->set_variable, var16, guid, attributes,
 		       datasize, data);
   grub_free (var16);
   if (status == GRUB_EFI_SUCCESS)
@@ -242,6 +239,16 @@ grub_efi_set_variable(const char *var, const grub_efi_guid_t *guid,
     return GRUB_ERR_NONE;
 
   return grub_error (GRUB_ERR_IO, "could not set EFI variable `%s'", var);
+}
+
+grub_err_t
+grub_efi_set_variable(const char *var, const grub_efi_guid_t *guid,
+		      void *data, grub_size_t datasize)
+{
+  return grub_efi_set_variable_with_attributes (var, guid, data, datasize, 
+			GRUB_EFI_VARIABLE_NON_VOLATILE
+			| GRUB_EFI_VARIABLE_BOOTSERVICE_ACCESS
+			| GRUB_EFI_VARIABLE_RUNTIME_ACCESS);
 }
 
 grub_efi_status_t

--- a/include/grub/efi/efi.h
+++ b/include/grub/efi/efi.h
@@ -128,6 +128,12 @@ grub_efi_status_t EXPORT_FUNC (grub_efi_get_variable) (const char *variable,
 						       grub_size_t *datasize_out,
 						       void **data_out);
 grub_err_t
+EXPORT_FUNC (grub_efi_set_variable_with_attributes) (const char *var,
+				     const grub_efi_guid_t *guid,
+				     void *data,
+				     grub_size_t datasize,
+             grub_uint32_t attribute);
+grub_err_t
 EXPORT_FUNC (grub_efi_set_variable) (const char *var,
 				     const grub_efi_guid_t *guid,
 				     void *data,

--- a/util/grub.d/25_boot_loader_interface.in
+++ b/util/grub.d/25_boot_loader_interface.in
@@ -1,0 +1,34 @@
+#!/usr/bin/sh
+set -e
+
+# grub-mkconfig helper script.
+# Copyright (C) 2020  Free Software Foundation, Inc.
+#
+# GRUB is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GRUB is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+
+prefix="/usr"
+exec_prefix="/usr"
+datarootdir="/usr/share"
+
+export TEXTDOMAIN=grub
+export TEXTDOMAINDIR="${datarootdir}/locale"
+
+. "$pkgdatadir/grub-mkconfig_lib"
+
+cat << EOF
+if [ "\$grub_platform" = "efi" ]; then
+  insmod boot-loader-interface
+  boot-loader-interface
+fi
+EOF


### PR DESCRIPTION
 Add a module for the Boot Loader Interface

Add a new module named boot-loader-interface, which provides a command
with the same name. It implements a small but quite useful part of the
[Boot Loader Interface](https://systemd.io/BOOT_LOADER_INTERFACE/). This interface uses EFI variables for communication between the boot loader
and the operating system.

This module sets two EFI variables under the vendor GUID
`4a67b082-0a4c-41cf-b6c7-440b29bb8c4f`:

- `LoaderInfo`: contains `GRUB + <version number>`.
  This allows the running operating system to identify the boot loader
  used during boot.

- `LoaderDevicePartUUID`: contains the partition UUID of the
  EFI System Partition (ESP).  This is used by
  [systemd-gpt-auto-genereator](https://www.freedesktop.org/software/systemd/man/systemd-gpt-auto-generator.html) to find the root partitions (and others
  too), [via partition type IDs](https://uapi-group.org/specifications/specs/discoverable_partitions_specification/).

This module is only available on EFI platforms.