### PR TITLE
core: Fix several implicit function declarations

### DIFF
--- a/grub-core/commands/efi/connectefi.c
+++ b/grub-core/commands/efi/connectefi.c
@@ -21,6 +21,7 @@
 #include <grub/efi/api.h>
 #include <grub/efi/pci.h>
 #include <grub/efi/efi.h>
+#include <grub/efi/disk.h>
 #include <grub/command.h>
 #include <grub/err.h>
 #include <grub/i18n.h>

--- a/grub-core/net/http.c
+++ b/grub-core/net/http.c
@@ -26,6 +26,7 @@
 #include <grub/dl.h>
 #include <grub/file.h>
 #include <grub/i18n.h>
+#include <grub/env.h>
 
 GRUB_MOD_LICENSE ("GPLv3+");
 

--- a/grub-core/term/at_keyboard.c
+++ b/grub-core/term/at_keyboard.c
@@ -25,6 +25,7 @@
 #include <grub/time.h>
 #include <grub/loader.h>
 #include <grub/ps2.h>
+#include <grub/env.h>
 
 GRUB_MOD_LICENSE ("GPLv3+");
 


### PR DESCRIPTION
These #include lines ensure that grub2 continues to build with C99 where implicit function declarations are removed.

Related to:

  <https://fedoraproject.org/wiki/Changes/PortingToModernC>
  <https://fedoraproject.org/wiki/Toolchain/PortingToModernC>