### PR TITLE
Discover unified kernel images on EFI

### DIFF
--- a/grub-core/commands/blscfg.c
+++ b/grub-core/commands/blscfg.c
@@ -99,7 +99,7 @@ static char *frob_boot_device(char *tmp)
   return grub_stpcpy (tmp, " " GRUB_BOOT_DEVICE);
 }
 
-static int bls_add_keyval(struct bls_entry *entry, char *key, char *val)
+static int bls_add_keyval(struct bls_entry *entry, const char *key, const char *val)
 {
   char *k, *v;
   struct keyval **kvs, *kv;

--- a/util/grub.d/10_linux.in
+++ b/util/grub.d/10_linux.in
@@ -276,6 +276,7 @@ EOF
 
 insmod blscfg
 blscfg
+blscfg_uki
 EOF
   fi
 


### PR DESCRIPTION
The `blscfg` module implements the Boot Loader Specification for "Type 1" entries = configuration snippets.
This PR extends this module to also handle "Type 2" entries: unified kernel images (UKI) by adding
a new command "blscfg_uki".  It searches for UKI in `/EFI/Linux` on the EFI partition and on `$root`
(probably `/boot`) and adds them to the menu.
