### PR TITLE
emu: Add switch-root to grub-emu

### DIFF
--- a/grub-core/kern/emu/main.c
+++ b/grub-core/kern/emu/main.c
@@ -108,6 +108,7 @@ static struct argp_option options[] = {
   {"verbose",     'v', 0,      0, N_("print verbose messages."), 0},
   {"hold",     'H', N_("SECS"),      OPTION_ARG_OPTIONAL, N_("wait until a debugger will attach"), 0},
   {"kexec",       'X', 0,      0, N_("use kexec to boot Linux kernels via systemctl (pass twice to enable dangerous fallback to non-systemctl)."), 0},
+  {"switch-root",     'W', 0,      0, N_("use switch-root to only switch root filesystem without restarting the kernel."), 0},
   { 0, 0, 0, 0, 0, 0 }
 };
 
@@ -168,7 +169,9 @@ argp_parser (int key, char *arg, struct argp_state *state)
     case 'X':
       grub_util_set_kexecute ();
       break;
-
+    case 'W':
+      grub_util_set_switch_root ();
+      break;
     case ARGP_KEY_ARG:
       {
 	/* Too many arguments. */

--- a/grub-core/kern/emu/misc.c
+++ b/grub-core/kern/emu/misc.c
@@ -40,6 +40,7 @@
 
 int verbosity;
 int kexecute;
+int switchroot = 0;
 
 void
 grub_util_warn (const char *fmt, ...)
@@ -230,4 +231,16 @@ int
 grub_util_get_kexecute (void)
 {
   return kexecute;
+}
+
+void
+grub_util_set_switch_root (void)
+{
+  switchroot = 1;
+}
+
+int
+grub_util_get_switch_root (void)
+{
+  return switchroot;
 }

--- a/include/grub/emu/exec.h
+++ b/include/grub/emu/exec.h
@@ -36,7 +36,7 @@ grub_util_exec_redirect_all (const char *const *argv, const char *stdin_file,
 int
 EXPORT_FUNC(grub_util_exec) (const char *const *argv);
 int
-grub_util_exec_redirect (const char *const *argv, const char *stdin_file,
+EXPORT_FUNC(grub_util_exec_redirect) (const char *const *argv, const char *stdin_file,
 			 const char *stdout_file);
 int
 grub_util_exec_redirect_null (const char *const *argv);

--- a/include/grub/emu/misc.h
+++ b/include/grub/emu/misc.h
@@ -59,6 +59,8 @@ void EXPORT_FUNC(grub_util_error) (const char *fmt, ...) __attribute__ ((format 
 
 void EXPORT_FUNC(grub_util_set_kexecute) (void);
 int EXPORT_FUNC(grub_util_get_kexecute) (void) WARN_UNUSED_RESULT;
+void EXPORT_FUNC(grub_util_set_switch_root) (void);
+int EXPORT_FUNC(grub_util_get_switch_root) (void);
 
 grub_uint64_t EXPORT_FUNC (grub_util_get_cpu_time_ms) (void);
 


### PR DESCRIPTION
If the kernel running grub emu is the same as the one we want to boot, it makes sense that we just switch-root instead of kexec the same kernel again by doing grub2-emu --switch-root