### PR TITLE
fix page fault (crash) on aarch64 UEFI firmware that provides EFI_MEMORY_ATTRIBUTE_PROTOCOL

### DIFF
--- a/grub-core/kern/dl.c
+++ b/grub-core/kern/dl.c
@@ -733,7 +733,8 @@ grub_dl_set_mem_attrs (grub_dl_t mod, void *ehdr)
     {
       tgsz = ALIGN_UP(tgsz, arch_addralign);
 
-      grub_dprintf ("modules", "updating attributes for GOT and trampolines\n",
+      grub_dprintf ("modules",
+		    "updating attributes for GOT and trampolines (\"%s\")\n",
 		    mod->name);
       grub_update_mem_attrs (tgaddr, tgsz, GRUB_MEM_ATTR_R|GRUB_MEM_ATTR_X,
 			     GRUB_MEM_ATTR_W);

--- a/grub-core/kern/dl.c
+++ b/grub-core/kern/dl.c
@@ -280,7 +280,9 @@ grub_dl_load_segments (grub_dl_t mod, const Elf_Ehdr *e)
   grub_size_t tsize = 0, talign = 1, arch_addralign = 1;
 #if !defined (__i386__) && !defined (__x86_64__) && !defined(__riscv)
   grub_size_t tramp;
+  grub_size_t tramp_align;
   grub_size_t got;
+  grub_size_t got_align;
   grub_err_t err;
 #endif
   char *ptr;
@@ -311,12 +313,18 @@ grub_dl_load_segments (grub_dl_t mod, const Elf_Ehdr *e)
   err = grub_arch_dl_get_tramp_got_size (e, &tramp, &got);
   if (err)
     return err;
-  tsize += ALIGN_UP (tramp, GRUB_ARCH_DL_TRAMP_ALIGN);
-  if (talign < GRUB_ARCH_DL_TRAMP_ALIGN)
-    talign = GRUB_ARCH_DL_TRAMP_ALIGN;
-  tsize += ALIGN_UP (got, GRUB_ARCH_DL_GOT_ALIGN);
-  if (talign < GRUB_ARCH_DL_GOT_ALIGN)
-    talign = GRUB_ARCH_DL_GOT_ALIGN;
+  tramp_align = GRUB_ARCH_DL_TRAMP_ALIGN;
+  if (tramp_align < arch_addralign)
+    tramp_align = arch_addralign;
+  tsize += ALIGN_UP (tramp, tramp_align);
+  if (talign < tramp_align)
+    talign = tramp_align;
+  got_align = GRUB_ARCH_DL_GOT_ALIGN;
+  if (got_align < arch_addralign)
+    got_align = arch_addralign;
+  tsize += ALIGN_UP (got, got_align);
+  if (talign < got_align)
+    talign = got_align;
 #endif
 
 #ifdef GRUB_MACHINE_EMU
@@ -376,11 +384,11 @@ grub_dl_load_segments (grub_dl_t mod, const Elf_Ehdr *e)
 	}
     }
 #if !defined (__i386__) && !defined (__x86_64__) && !defined(__riscv)
-  ptr = (char *) ALIGN_UP ((grub_addr_t) ptr, GRUB_ARCH_DL_TRAMP_ALIGN);
+  ptr = (char *) ALIGN_UP ((grub_addr_t) ptr, tramp_align);
   mod->tramp = ptr;
   mod->trampptr = ptr;
   ptr += tramp;
-  ptr = (char *) ALIGN_UP ((grub_addr_t) ptr, GRUB_ARCH_DL_GOT_ALIGN);
+  ptr = (char *) ALIGN_UP ((grub_addr_t) ptr, got_align);
   mod->got = ptr;
   mod->gotptr = ptr;
   ptr += got;


### PR DESCRIPTION
Downstream commits 887f1d8fa976 and ad1b904d325b (on the `rhel-9-main` branch) introduce a crash on such aarch64 UEFI platform firmware that provides EFI_MEMORY_ATTRIBUTE_PROTOCOL. This series aims to fix the crash. For more details, please see the individual commit messages in the series (especially the middle one).

This PR targets the `rhel-9-main` branch, but it should identically apply to `fedora-39`, as at the time of this writing, the `grub-core/kern/dl.c` file, which is the sole file that the series modifies, is identical between those branches (with `HEAD`s being at commits 61616e1efb5b and b09440df0575, respectively).

Thanks!