### PR TITLE
Rhel 9 main

### DIFF
--- a/grub-core/kern/ieee1275/init.c
+++ b/grub-core/kern/ieee1275/init.c
@@ -72,6 +72,12 @@ extern char _end[];
 grub_addr_t grub_ieee1275_original_stack;
 #endif
 
+#define LPAR     0x80
+#define SPLPAR   0x40
+#define BYTE2    (LPAR | SPLPAR)
+#define CMO      0x80
+#define MAX_CPU  256
+
 void
 grub_exit (int rc __attribute__((unused)))
 {
@@ -575,7 +581,7 @@ grub_ieee1275_ibm_cas (void)
     .vec4 = 0x0001, /* set required minimum capacity % to the lowest value */
     .vec5_size = 1 + sizeof (struct option_vector5) - 2,
     .vec5 = {
-      0, 192, 0, 128, 0, 0, 0, 0, 256
+      0, BYTE2, 0, CMO, 0, 0, 0, 0, MAX_CPU
     }
   };
 

--- a/grub-core/kern/ieee1275/init.c
+++ b/grub-core/kern/ieee1275/init.c
@@ -72,11 +72,41 @@ extern char _end[];
 grub_addr_t grub_ieee1275_original_stack;
 #endif
 
-#define LPAR     0x80
-#define SPLPAR   0x40
-#define BYTE2    (LPAR | SPLPAR)
-#define CMO      0x80
-#define MAX_CPU  256
+/* Options vector5 properties. */
+
+#define LPAR                0x80
+#define SPLPAR              0x40
+#define DYN_RCON_MEM        0x20
+#define LARGE_PAGES         0x10
+#define DONATE_DCPU_CLS     0x02
+#define PCI_EXP             0x01
+#define BYTE2               (LPAR | SPLPAR | DYN_RCON_MEM | LARGE_PAGES | DONATE_DCPU_CLS | PCI_EXP)
+
+#define CMOC                0x80
+#define EXT_CMO             0x40
+#define CMO                 (CMOC | EXT_CMO)
+
+#define ASSOC_REF           0x80
+#define AFFINITY            0x40
+#define NUMA                0x20
+#define ASSOCIATIVITY       (ASSOC_REF | AFFINITY | NUMA)
+
+#define HOTPLUG_INTRPT      0x04
+#define HPT_RESIZE          0x01
+#define BIN_OPTS            (HOTPLUG_INTRPT | HPT_RESIZE)
+
+#define MAX_CPU             256
+
+#define PFO_HWRNG           0x80000000
+#define PFO_HW_COMP         0x40000000
+#define PFO_ENCRYPT         0x20000000
+#define PLATFORM_FACILITIES (PFO_HWRNG | PFO_HW_COMP | PFO_ENCRYPT)
+
+#define SUB_PROCESSORS      1
+
+#define DY_MEM_V2           0x80
+#define DRC_INFO            0x40
+#define BYTE22              (DY_MEM_V2 | DRC_INFO)
 
 void
 grub_exit (int rc __attribute__((unused)))
@@ -519,6 +549,11 @@ struct option_vector5
   grub_uint8_t micro_checkpoint;
   grub_uint8_t reserved0;
   grub_uint32_t max_cpus;
+  grub_uint16_t base_papr;
+  grub_uint16_t mem_reference;
+  grub_uint32_t platform_facilities;
+  grub_uint8_t sub_processors;
+  grub_uint8_t byte22;
 } GRUB_PACKED;
 
 struct pvr_entry
@@ -581,7 +616,7 @@ grub_ieee1275_ibm_cas (void)
     .vec4 = 0x0001, /* set required minimum capacity % to the lowest value */
     .vec5_size = 1 + sizeof (struct option_vector5) - 2,
     .vec5 = {
-      0, BYTE2, 0, CMO, 0, 0, 0, 0, MAX_CPU
+      0, BYTE2, 0, CMO, ASSOCIATIVITY, BIN_OPTS, 0, 0, MAX_CPU, 0, 0, PLATFORM_FACILITIES, SUB_PROCESSORS, BYTE22
     }
   };
 

--- a/include/grub/efi/http.h
+++ b/include/grub/efi/http.h
@@ -171,9 +171,9 @@ typedef struct {
     grub_efi_http_request_data_t *request;
     grub_efi_http_response_data_t *response;
   } data;
-  grub_efi_uint32_t header_count;
+  grub_efi_uintn_t header_count;
   grub_efi_http_header_t *headers;
-  grub_efi_uint32_t body_length;
+  grub_efi_uintn_t body_length;
   void *body;
 } grub_efi_http_message_t;
 

--- a/util/grub-get-kernel-settings.in
+++ b/util/grub-get-kernel-settings.in
@@ -68,6 +68,14 @@ if test -f /etc/sysconfig/kernel ; then
     . /etc/sysconfig/kernel
 fi
 
+GRUB_DEFAULT_KERNEL_TYPE=${DEFAULTKERNEL/-core/}
+if [ "$GRUB_DEFAULT_KERNEL_TYPE" != "kernel" ]; then
+    echo GRUB_NON_STANDARD_KERNEL=true
+    echo export GRUB_NON_STANDARD_KERNEL
+    GRUB_DEFAULT_KERNEL_TYPE=${GRUB_DEFAULT_KERNEL_TYPE/kernel-/}
+fi
+echo GRUB_DEFAULT_KERNEL_TYPE=$GRUB_DEFAULT_KERNEL_TYPE
+echo export GRUB_DEFAULT_KERNEL_TYPE
 if [ "$MAKEDEBUG" = "yes" ]; then
     echo GRUB_LINUX_MAKE_DEBUG=true
     echo export GRUB_LINUX_MAKE_DEBUG


### PR DESCRIPTION
Couple of fixes for:
- [[HPE 9.2 aarch Bug] HTTP boot issue on RL300](https://bugzilla.redhat.com/show_bug.cgi?id=2207851)
- [RHEL9-SP6-SAP:Not able to activate SAP VM which deployed with SAP Large Profile mh1-90x16200](https://bugzilla.redhat.com/show_bug.cgi?id=2183939)
- [[RHEL-9.3] kernel/install.d/20-grub.install improperly handles non-debug kernel variants](https://bugzilla.redhat.com/show_bug.cgi?id=2184069)