### PR TITLE
grub-mkconfig dont overwrite BLS cmdline if BLSCFG

### DIFF
--- a/util/grub-mkconfig.in
+++ b/util/grub-mkconfig.in
@@ -51,6 +51,7 @@ export TEXTDOMAIN=@PACKAGE@
 export TEXTDOMAINDIR="@localedir@"
 
 export GRUB_GRUBENV_UPDATE="yes"
+export GRUB_UPDATE_BLS_CMDLINE="yes"
 
 . "${pkgdatadir}/grub-mkconfig_lib"
 
@@ -62,6 +63,7 @@ usage () {
     echo
     print_option_help "-o, --output=$(gettext FILE)" "$(gettext "output generated config to FILE [default=stdout]")"
     print_option_help "--no-grubenv-update" "$(gettext "do not update variables in the grubenv file")"
+    print_option_help "--update-bls-cmdline" "$(gettext "overwrite BLS cmdline args with default args")"
     print_option_help "-h, --help" "$(gettext "print this message and exit")"
     print_option_help "-V, --version" "$(gettext "print the version information and exit")"
     echo
@@ -99,6 +101,9 @@ do
 	;;
     --no-grubenv-update)
 	GRUB_GRUBENV_UPDATE="no"
+	;;
+    --update-bls-cmdline)
+	bls_cmdline_update=true
 	;;
     -*)
 	gettext_printf "Unrecognized option \`%s'\n" "$option" 1>&2
@@ -166,6 +171,10 @@ if test -f ${sysconfdir}/default/grub ; then
 fi
 
 eval "$("${grub_get_kernel_settings}")" || true
+
+if [ "x${GRUB_ENABLE_BLSCFG}" = "xtrue" ] && [ "x${bls_cmdline_update}" != "xtrue" ]; then
+  GRUB_UPDATE_BLS_CMDLINE="no"
+fi
 
 if [ "x${GRUB_DISABLE_UUID}" = "xtrue" ]; then
   if [ -z "${GRUB_DISABLE_LINUX_UUID}" ]; then

--- a/util/grub.d/10_linux.in
+++ b/util/grub.d/10_linux.in
@@ -265,7 +265,7 @@ if [ -z "\${kernelopts}" ]; then
 fi
 EOF
 
-  if [ "x${GRUB_GRUBENV_UPDATE}" = "xyes" ]; then
+  if [ "x${GRUB_UPDATE_BLS_CMDLINE}" = "xyes" ]; then
       update_bls_cmdline
   fi
 


### PR DESCRIPTION
If GRUB_ENABLE_BLSCFG is true, running grub2-mkconfig will not overwrite kernel cmdline in BLS snippets with what is in GRUB_CMDLINE_LINUX in /etc/default/grub. Update can be forced by sending new arg --update-bls-cmdline