### PR TITLE
Add [Install] section to aux systemd units

### DIFF
--- a/docs/grub-boot-indeterminate.service
+++ b/docs/grub-boot-indeterminate.service
@@ -9,3 +9,6 @@ Before=system-update-pre.target
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/grub2-editenv - incr boot_indeterminate
+
+[Install]
+WantedBy=system-update.target

--- a/docs/grub-boot-success.timer
+++ b/docs/grub-boot-success.timer
@@ -5,3 +5,6 @@ ConditionVirtualization=!container
 
 [Timer]
 OnActiveSec=2min
+
+[Install]
+WantedBy=timers.target

--- a/util/systemd/grub-systemd-integration.service.in
+++ b/util/systemd/grub-systemd-integration.service.in
@@ -6,3 +6,6 @@ ConditionPathExists=/run/systemd/reboot-to-boot-loader-menu
 
 [Service]
 ExecStart=@libexecdir@/@grubdirname@/systemd-integration.sh
+
+[Install]
+WantedBy=reboot.target


### PR DESCRIPTION
Currently in Fedora, these services are statically enabled by symlinks, with no other way to disable them than to manually delete those symlinks:

https://src.fedoraproject.org/rpms/grub2/blob/dc5c4e3f52ab2a829168e81bd1e9eafced9b7c09/f/grub2.spec#_274-284

This is problematic in Fedora IoT, where grub-boot-success.timer is not supposed to be enabled.

This change adds `[Install]` sections to all systemd units that are currently enabled statically, so that they can be enabled dynamically via presets or manually via systemctl instead.

See
- https://bugzilla.redhat.com/show_bug.cgi?id=2230575
- https://github.com/fedora-iot/greenboot/issues/108