### PR TITLE
grub-install on EFI if forced

### DIFF
--- a/util/grub-install.c
+++ b/util/grub-install.c
@@ -899,22 +899,6 @@ main (int argc, char *argv[])
 
   platform = grub_install_get_target (grub_install_source_directory);
 
-  switch (platform)
-    {
-    case GRUB_INSTALL_PLATFORM_ARM_EFI:
-    case GRUB_INSTALL_PLATFORM_ARM64_EFI:
-    case GRUB_INSTALL_PLATFORM_I386_EFI:
-    case GRUB_INSTALL_PLATFORM_IA64_EFI:
-    case GRUB_INSTALL_PLATFORM_X86_64_EFI:
-      is_efi = 1;
-      grub_util_error (_("this utility cannot be used for EFI platforms"
-                         " because it does not support UEFI Secure Boot"));
-      break;
-    default:
-      is_efi = 0;
-      break;
-    }
-
   {
     char *platname = grub_install_get_platform_name (platform);
     fprintf (stderr, _("Installing for %s platform.\n"), platname);
@@ -1026,6 +1010,32 @@ main (int argc, char *argv[])
   grub_gcry_init_all ();
   grub_hostfs_init ();
   grub_host_init ();
+
+  switch (platform)
+    {
+    case GRUB_INSTALL_PLATFORM_I386_EFI:
+    case GRUB_INSTALL_PLATFORM_X86_64_EFI:
+    case GRUB_INSTALL_PLATFORM_ARM_EFI:
+    case GRUB_INSTALL_PLATFORM_ARM64_EFI:
+    case GRUB_INSTALL_PLATFORM_RISCV32_EFI:
+    case GRUB_INSTALL_PLATFORM_RISCV64_EFI:
+    case GRUB_INSTALL_PLATFORM_IA64_EFI:
+      is_efi = 1;
+      if (!force)
+        grub_util_error (_("This utility should not be used for EFI platforms"
+                          " because it does not support UEFI Secure Boot."
+                          " If you really wish to proceed, invoke the --force"
+                          " option.\nMake sure Secure Boot is disabled before"
+                          " proceeding"));
+      break;
+    default:
+      is_efi = 0;
+      break;
+
+      /* pacify warning.  */
+    case GRUB_INSTALL_PLATFORM_MAX:
+      break;
+    }
 
   /* Find the EFI System Partition.  */
   if (is_efi)


### PR DESCRIPTION
UEFI Secure Boot requires signed grub binaries to work, so grub- install should not be used. However, users who have Secure Boot disabled and wish to use the command should not be prevented from doing so if they invoke --force.

fixes bz#1917213 / bz#2240994