### PR TITLE
Fix checking sscanf return value as the value can be 0 causing overflow in snprintf

### DIFF
--- a/grub-core/osdep/linux/ofpath.c
+++ b/grub-core/osdep/linux/ofpath.c
@@ -292,6 +292,8 @@ __of_path_common(char *sysfs_path,
       int part;
 
       sscanf(digit_string, "%d", &part);
+      if (part < 1) 
+        return NULL;
       snprintf(disk, sizeof (disk), "/disk@%d:%c", devno, 'a' + (part - 1));
     }
   strcat(of_path, disk);


### PR DESCRIPTION
Since device is taken as an argument (`argv[1]`), in [ofcpath.c](https://github.com/rhboot/grub2/blob/fedora-39/grub-core/osdep/linux/ofpath.c#L294), a seemingly malicious device for instance the string `/pci@1f,0/pci@1/scsi@8/sd@0,0` can cause sscanf to return 0 and in turn cause `part` to become negative in snprintf and cause undefined behaviour. 