### PR TITLE
chainloader: remove device path debug message

### DIFF
--- a/grub-core/loader/efi/chainloader.c
+++ b/grub-core/loader/efi/chainloader.c
@@ -210,7 +210,6 @@ make_file_path (grub_efi_device_path_t *dp, const char *filename)
   /* Fill the file path for the directory.  */
   d = (grub_efi_device_path_t *) ((char *) file_path
 				  + ((char *) d - (char *) dp));
-  grub_efi_print_device_path (d);
   if (copy_file_path ((grub_efi_file_path_device_path_t *) d,
 		      dir_start, dir_end - dir_start) != GRUB_ERR_NONE)
     {


### PR DESCRIPTION
Remove the debug message "/EndEntire" while using GRUB chainloader command.