### PR TITLE
normal: Remove grub_env_set prefix in grub_try_normal_prefix

### DIFF
--- a/grub-core/normal/main.c
+++ b/grub-core/normal/main.c
@@ -372,7 +372,6 @@ grub_try_normal_prefix (const char *prefix)
            file = grub_file_open (config, GRUB_FILE_TYPE_CONFIG);
            if (file)
              {
-               grub_env_set ("prefix", prefix);
                grub_file_close (file);
                err = GRUB_ERR_NONE;
              }


### PR DESCRIPTION
Commit de735a453aa35 added a grub_env_set where the prefix contains the arch name in the pathname. This create issues when trying to load modules using this prefix as the pathname contains a "doubled" arch name in it (ie .../powerpc-ieee1275/powerpc-ieee1275/).