### PR TITLE
Set non-executable stack sections on EFI assembly files

### DIFF
--- a/grub-core/kern/i386/efi/startup.S
+++ b/grub-core/kern/i386/efi/startup.S
@@ -34,3 +34,8 @@ _start:
 	movl	%eax, EXT_C(grub_efi_system_table)
 	call	EXT_C(grub_main)
 	ret
+
+/* An executable stack is not required for these functions. */
+#if defined (__linux__) && defined (__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/grub-core/kern/x86_64/efi/callwrap.S
+++ b/grub-core/kern/x86_64/efi/callwrap.S
@@ -127,3 +127,8 @@ FUNCTION(efi_wrap_10)
 	call *%rdi
 	addq $88, %rsp
 	ret
+
+/* An executable stack is not required for these functions. */
+#if defined (__linux__) && defined (__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/grub-core/kern/x86_64/efi/startup.S
+++ b/grub-core/kern/x86_64/efi/startup.S
@@ -33,3 +33,8 @@ _start:
 	andq	$~0xf, %rsp
 	call	EXT_C(grub_main)
 	/* Doesn't return.  */
+
+/* An executable stack is not required for these functions. */
+#if defined (__linux__) && defined (__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
For those manual assembly files created where no '.note.GNU-stack' section is explicitly added, linker defaults it as executable and this is the reason that RHEL CI rpminspect & annocheck tests are failing. The proposed change sets the corresponding GNU-stack sections otherwise CI detects the following security vulnerability

   $ annocheck annocheck --ignore-unknown --verbose --profile=el9 *.rpm 2>&1 | grep FAIL | grep stack
   (standard input):(standard input):Hardened: ./usr/lib/grub/x86_64-efi/kernel.exec: FAIL: gnu-stack test because .note.GNU-stack section has execute permission
   (standard input):(standard input):Hardened: ./usr/lib/grub/x86_64-efi/kernel.img: FAIL: gnu-stack test because .note.GNU-stack section has execute permission