### PR TITLE
Fedora 39 dist-git sync from Patch0347 to Patch0359

### DIFF
--- a/grub-core/commands/search.c
+++ b/grub-core/commands/search.c
@@ -87,11 +87,40 @@ iterate_device (const char *name, void *data)
     }
 
   /* Skip it if it's not the root device when requested. */
-  root_dev = grub_env_get ("root");
-  if (ctx->flags & SEARCH_FLAGS_ROOTDEV_ONLY &&
-      (name[0] != root_dev[0] || name[1] != root_dev[1] ||
-       name[2] != root_dev[2]))
-    return 0;
+  if (ctx->flags & SEARCH_FLAGS_ROOTDEV_ONLY)
+    {
+      const char *root_dev;
+      root_dev = grub_env_get ("root");
+      if (root_dev != NULL && *root_dev != '\0')
+      {
+        char *root_disk = grub_malloc (grub_strlen(root_dev) + 1);
+        char *name_disk = grub_malloc (grub_strlen(name) + 1);
+        char *rem_1 = grub_malloc(grub_strlen(root_dev) + 1);
+        char *rem_2 = grub_malloc(grub_strlen(name) + 1);
+
+	if (root_disk != NULL && name_disk != NULL && 
+	    rem_1 != NULL && rem_2 != NULL)
+  	  {
+            /* get just the disk name; partitions will be different. */
+            grub_str_sep (root_dev, root_disk, ',', rem_1);
+            grub_str_sep (name, name_disk, ',', rem_2);
+            if (root_disk != NULL && *root_disk != '\0' &&
+    	        name_disk != NULL && *name_disk != '\0')
+              if (grub_strcmp(root_disk, name_disk) != 0)
+                {
+                  grub_free (root_disk);
+                  grub_free (name_disk);
+                  grub_free (rem_1);
+                  grub_free (rem_2);
+                  return 0;
+                }
+	  }
+        grub_free (root_disk);
+        grub_free (name_disk);
+        grub_free (rem_1);
+        grub_free (rem_2);
+      }
+    }
 
 #ifdef DO_SEARCH_FS_UUID
 #define compare_fn grub_strcasecmp

--- a/grub-core/fs/ntfs.c
+++ b/grub-core/fs/ntfs.c
@@ -839,6 +839,25 @@ grub_ntfs_iterate_dir (grub_fshelp_node_t dir,
 
 	  if (is_resident)
 	    {
+              if (bitmap_len > (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR))
+		{
+		  grub_error (GRUB_ERR_BAD_FS, "resident bitmap too large");
+		  goto done;
+		}
+
+              if (cur_pos >= at->mft->buf + (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR))
+		{
+		  grub_error (GRUB_ERR_BAD_FS, "resident bitmap out of range");
+		  goto done;
+		}
+
+              if (u16at (cur_pos, 0x14) + u32at (cur_pos, 0x10) >
+		  (grub_addr_t) at->mft->buf + (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR) - (grub_addr_t) cur_pos)
+		{
+		  grub_error (GRUB_ERR_BAD_FS, "resident bitmap out of range");
+		  goto done;
+		}
+
               grub_memcpy (bmp, cur_pos + u16at (cur_pos, 0x14),
                            bitmap_len);
 	    }

--- a/grub-core/fs/ntfs.c
+++ b/grub-core/fs/ntfs.c
@@ -52,6 +52,24 @@ u64at (void *ptr, grub_size_t ofs)
   return grub_le_to_cpu64 (grub_get_unaligned64 ((char *) ptr + ofs));
 }
 
+static grub_uint16_t
+first_attr_off (void *mft_buf_ptr)
+{
+  return u16at (mft_buf_ptr, 0x14);
+}
+
+static grub_uint16_t
+res_attr_data_off (void *res_attr_ptr)
+{
+  return u16at (res_attr_ptr, 0x14);
+}
+
+static grub_uint32_t
+res_attr_data_len (void *res_attr_ptr)
+{
+  return u32at (res_attr_ptr, 0x10);
+}
+
 grub_ntfscomp_func_t grub_ntfscomp_func;
 
 static grub_err_t
@@ -106,7 +124,7 @@ init_attr (struct grub_ntfs_attr *at, struct grub_ntfs_file *mft)
 {
   at->mft = mft;
   at->flags = (mft == &mft->data->mmft) ? GRUB_NTFS_AF_MMFT : 0;
-  at->attr_nxt = mft->buf + u16at (mft->buf, 0x14);
+  at->attr_nxt = mft->buf + first_attr_off (mft->buf);
   at->attr_end = at->emft_buf = at->edat_buf = at->sbuf = NULL;
 }
 
@@ -154,7 +172,7 @@ find_attr (struct grub_ntfs_attr *at, grub_uint8_t attr)
 		    return NULL;
 		}
 
-	      new_pos = &at->emft_buf[u16at (at->emft_buf, 0x14)];
+	      new_pos = &at->emft_buf[first_attr_off (at->emft_buf)];
 	      while (*new_pos != 0xFF)
 		{
 		  if ((*new_pos == *at->attr_cur)
@@ -213,7 +231,7 @@ find_attr (struct grub_ntfs_attr *at, grub_uint8_t attr)
 	}
       else
 	{
-	  at->attr_nxt = at->attr_end + u16at (pa, 0x14);
+	  at->attr_nxt = at->attr_end + res_attr_data_off (pa);
 	  at->attr_end = at->attr_end + u32at (pa, 4);
 	  pa_end = at->mft->buf + (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR);
 	}
@@ -399,20 +417,20 @@ read_data (struct grub_ntfs_attr *at, grub_uint8_t *pa, grub_uint8_t *dest,
 
   if (pa[8] == 0)
     {
-      if (ofs + len > u32at (pa, 0x10))
+      if (ofs + len > res_attr_data_len (pa))
 	return grub_error (GRUB_ERR_BAD_FS, "read out of range");
 
-      if (u32at (pa, 0x10) > (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR))
+      if (res_attr_data_len (pa) > (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR))
 	return grub_error (GRUB_ERR_BAD_FS, "resident attribute too large");
 
       if (pa >= at->mft->buf + (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR))
 	return grub_error (GRUB_ERR_BAD_FS, "resident attribute out of range");
 
-      if (u16at (pa, 0x14) + u32at (pa, 0x10) >
+      if (res_attr_data_off (pa) + res_attr_data_len (pa) >
 	  (grub_addr_t) at->mft->buf + (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR) - (grub_addr_t) pa)
 	return grub_error (GRUB_ERR_BAD_FS, "resident attribute out of range");
 
-      grub_memcpy (dest, pa + u16at (pa, 0x14) + ofs, len);
+      grub_memcpy (dest, pa + res_attr_data_off (pa) + ofs, len);
       return 0;
     }
 
@@ -556,7 +574,7 @@ init_file (struct grub_ntfs_file *mft, grub_uint64_t mftno)
 			   (unsigned long long) mftno);
 
       if (!pa[8])
-	mft->size = u32at (pa, 0x10);
+	mft->size = res_attr_data_len (pa);
       else
 	mft->size = u64at (pa, 0x30);
 
@@ -801,7 +819,7 @@ grub_ntfs_iterate_dir (grub_fshelp_node_t dir,
 	  (u32at (cur_pos, 0x18) != 0x490024) ||
 	  (u32at (cur_pos, 0x1C) != 0x300033))
 	continue;
-      cur_pos += u16at (cur_pos, 0x14);
+      cur_pos += res_attr_data_off (cur_pos);
       if (*cur_pos != 0x30)	/* Not filename index */
 	continue;
       break;
@@ -830,7 +848,7 @@ grub_ntfs_iterate_dir (grub_fshelp_node_t dir,
 	{
           int is_resident = (cur_pos[8] == 0);
 
-          bitmap_len = ((is_resident) ? u32at (cur_pos, 0x10) :
+          bitmap_len = ((is_resident) ? res_attr_data_len (cur_pos) :
                         u32at (cur_pos, 0x28));
 
           bmp = grub_malloc (bitmap_len);
@@ -851,14 +869,14 @@ grub_ntfs_iterate_dir (grub_fshelp_node_t dir,
 		  goto done;
 		}
 
-              if (u16at (cur_pos, 0x14) + u32at (cur_pos, 0x10) >
+              if (res_attr_data_off (cur_pos) + res_attr_data_len (cur_pos) >
 		  (grub_addr_t) at->mft->buf + (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR) - (grub_addr_t) cur_pos)
 		{
 		  grub_error (GRUB_ERR_BAD_FS, "resident bitmap out of range");
 		  goto done;
 		}
 
-              grub_memcpy (bmp, cur_pos + u16at (cur_pos, 0x14),
+              grub_memcpy (bmp, cur_pos + res_attr_data_off (cur_pos),
                            bitmap_len);
 	    }
           else
@@ -1222,12 +1240,12 @@ grub_ntfs_label (grub_device_t device, char **label)
       goto fail;
     }
 
-  if ((pa) && (pa[8] == 0) && (u32at (pa, 0x10)))
+  if ((pa) && (pa[8] == 0) && (res_attr_data_len (pa)))
     {
       int len;
 
-      len = u32at (pa, 0x10) / 2;
-      pa += u16at (pa, 0x14);
+      len = res_attr_data_len (pa) / 2;
+      pa += res_attr_data_off (pa);
       if (mft->buf + (mft->data->mft_size << GRUB_NTFS_BLK_SHR) - pa >= 2 * len)
         *label = get_utf8 (pa, len);
       else

--- a/grub-core/fs/xfs.c
+++ b/grub-core/fs/xfs.c
@@ -902,6 +902,7 @@ grub_xfs_iterate_dir (grub_fshelp_node_t dir,
 					grub_xfs_first_de(dir->data, dirblock);
 	    int entries = -1;
 	    char *end = dirblock + dirblk_size;
+	    grub_uint32_t magic;
 
 	    numread = grub_xfs_read_file (dir, 0, 0,
 					  blk << dirblk_log2,
@@ -911,6 +912,15 @@ grub_xfs_iterate_dir (grub_fshelp_node_t dir,
 	        grub_free (dirblock);
 	        return 0;
 	      }
+
+	    /*
+	     * If this data block isn't actually part of the extent list then
+	     * grub_xfs_read_file() returns a block of zeros. So, if the magic
+	     * number field is all zeros then this block should be skipped.
+	     */
+	    magic = *(grub_uint32_t *)(void *) dirblock;
+	    if (!magic)
+	      continue;
 
 	    /*
 	     * Leaf and tail information are only in the data block if the number

--- a/grub-core/kern/misc.c
+++ b/grub-core/kern/misc.c
@@ -619,6 +619,36 @@ grub_reverse (char *str)
     }
 }
 
+/* Separate string into two parts, broken up by delimiter delim. */
+void
+grub_str_sep (const char *s, char *p, char delim, char *r)
+{
+  char* t = grub_strndup(s, grub_strlen(s));
+
+  if (t != NULL && *t != '\0')
+  {
+    char* tmp = t;
+  
+    while (((*p = *t) != '\0') && ((*p = *t) != delim))
+    {
+      p++;
+      t++;
+    }
+    *p = '\0';
+  
+    if (*t != '\0')
+    {
+      t++;
+      while ((*r++ = *t++) != '\0')
+        ;
+      *r = '\0';
+    }
+    grub_free (tmp);
+  }
+  else
+    grub_free (t);
+}
+
 /* Divide N by D, return the quotient, and store the remainder in *R.  */
 grub_uint64_t
 grub_divmod64 (grub_uint64_t n, grub_uint64_t d, grub_uint64_t *r)

--- a/grub-core/normal/main.c
+++ b/grub-core/normal/main.c
@@ -372,7 +372,6 @@ grub_try_normal_prefix (const char *prefix)
            file = grub_file_open (config, GRUB_FILE_TYPE_CONFIG);
            if (file)
              {
-               grub_env_set ("prefix", prefix);
                grub_file_close (file);
                err = GRUB_ERR_NONE;
              }

--- a/include/grub/misc.h
+++ b/include/grub/misc.h
@@ -314,6 +314,7 @@ void *EXPORT_FUNC(grub_memset) (void *s, int c, grub_size_t n);
 grub_size_t EXPORT_FUNC(grub_strlen) (const char *s) WARN_UNUSED_RESULT;
 int EXPORT_FUNC(grub_printf) (const char *fmt, ...) __attribute__ ((format (GNU_PRINTF, 1, 2)));
 int EXPORT_FUNC(grub_printf_) (const char *fmt, ...) __attribute__ ((format (GNU_PRINTF, 1, 2)));
+void EXPORT_FUNC(grub_str_sep) (const char *s, char *p, char delim, char *r);
 
 /* Replace all `ch' characters of `input' with `with' and copy the
    result into `output'; return EOS address of `output'. */

--- a/util/grub-set-bootflag.c
+++ b/util/grub-set-bootflag.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/resource.h>
 
@@ -60,15 +61,12 @@ int main(int argc, char *argv[])
 {
   /* NOTE buf must be at least the longest bootflag length + 4 bytes */
   char env[GRUBENV_SIZE + 1 + 2], buf[64], *s;
-  /* +1 for 0 termination, +6 for "XXXXXX" in tmp filename */
-  char env_filename[PATH_MAX + 1], tmp_filename[PATH_MAX + 6 + 1];
+  /* +1 for 0 termination, +11 for ".%u" in tmp filename */
+  char env_filename[PATH_MAX + 1], tmp_filename[PATH_MAX + 11 + 1];
   const char *bootflag;
   int i, fd, len, ret;
   FILE *f;
-  struct rlimit rlim;
 
-  if (getrlimit(RLIMIT_FSIZE, &rlim) || rlim.rlim_cur < GRUBENV_SIZE || rlim.rlim_max < GRUBENV_SIZE)
-    return 1;
   umask(077);
 
   if (argc != 2)
@@ -105,7 +103,7 @@ int main(int argc, char *argv[])
    */
   if (setegid(0))
     {
-      perror ("Error setegid(0) failed");
+      perror ("setegid(0) failed");
       return 1;
     }
 
@@ -176,18 +174,81 @@ int main(int argc, char *argv[])
     return 0; /* nothing to do */
   memcpy(s, buf, len + 3);
 
+  struct rlimit rlim;
+  if (getrlimit(RLIMIT_FSIZE, &rlim) || rlim.rlim_cur < GRUBENV_SIZE || rlim.rlim_max < GRUBENV_SIZE)
+    {
+      fprintf (stderr, "Resource limits undetermined or too low\n");
+      return 1;
+    }
+
+  /*
+   * Here we work under the premise that we shouldn't write into the target
+   * file directly because we might not be able to have all of our changes
+   * written completely and atomically.  That was CVE-2019-14865, known to
+   * have been triggerable via RLIMIT_FSIZE.  While we've dealt with that
+   * specific attack via the check above, there may be other possibilities.
+   */
 
   /*
    * Create a tempfile for writing the new env.  Use the canonicalized filename
    * for the template so that the tmpfile is in the same dir / on same fs.
+   *
+   * We now use per-user fixed temporary filenames, so that a user cannot cause
+   * multiple files to accumulate.
+   *
+   * We don't use O_EXCL so that a stale temporary file doesn't prevent further
+   * usage of the program by the user.
    */
-  snprintf(tmp_filename, sizeof(tmp_filename), "%sXXXXXX", env_filename);
-  fd = mkstemp(tmp_filename);
+  snprintf(tmp_filename, sizeof(tmp_filename), "%s.%u", env_filename, getuid());
+  fd = open(tmp_filename, O_CREAT | O_WRONLY, 0600);
   if (fd == -1)
     {
       perror ("Creating tmpfile failed");
       return 1;
     }
+
+  /*
+   * The lock prevents the same user from reaching further steps ending in
+   * rename() concurrently, in which case the temporary file only partially
+   * written by one invocation could be renamed to the target file by another.
+   *
+   * The lock also guards the slow fsync() from concurrent calls.  After the
+   * first time that and the rename() complete, further invocations for the
+   * same flag become no-ops.
+   *
+   * We lock the temporary file rather than the target file because locking the
+   * latter would allow any user having SIGSTOP'ed their process to make all
+   * other users' invocations fail (or lock up if we'd use blocking mode).
+   *
+   * We use non-blocking mode (LOCK_NB) because the lock having been taken by
+   * another process implies that the other process would normally have already
+   * renamed the file to target by the time it releases the lock (and we could
+   * acquire it), so we'd be working directly on the target if we proceeded,
+   * which is undesirable, and we'd kind of fail on the already-done rename.
+   */
+  if (flock(fd, LOCK_EX | LOCK_NB))
+    {
+      perror ("Locking tmpfile failed");
+      return 1;
+    }
+
+  /*
+   * Deal with the potential that another invocation proceeded all the way to
+   * rename() and process exit while we were between open() and flock().
+   */
+  {
+    struct stat st1, st2;
+    if (fstat(fd, &st1) || stat(tmp_filename, &st2))
+      {
+        perror ("stat of tmpfile failed");
+        return 1;
+      }
+    if (st1.st_dev != st2.st_dev || st1.st_ino != st2.st_ino)
+      {
+        fprintf (stderr, "Another invocation won race\n");
+        return 1;
+      }
+  }
 
   f = fdopen (fd, "w");
   if (!f)
@@ -213,6 +274,14 @@ int main(int argc, char *argv[])
       return 1;     
     }
 
+  ret = ftruncate (fileno (f), GRUBENV_SIZE);
+  if (ret)
+    {
+      perror ("Error truncating tmpfile");
+      unlink(tmp_filename);
+      return 1;
+    }
+
   ret = fsync (fileno (f));
   if (ret)
     {
@@ -221,15 +290,9 @@ int main(int argc, char *argv[])
       return 1;
     }
 
-  ret = fclose (f);
-  if (ret)
-    {
-      perror ("Error closing tmpfile");
-      unlink(tmp_filename);
-      return 1;
-    }
-
   /*
+   * We must not close the file before rename() as that would remove the lock.
+   *
    * And finally rename the tmpfile with the new env over the old env, the
    * linux kernel guarantees that this is atomic (from a syscall pov).
    */

--- a/util/grub-set-bootflag.c
+++ b/util/grub-set-bootflag.c
@@ -99,6 +99,17 @@ int main(int argc, char *argv[])
   len = strlen (bootflag);
 
   /*
+   * Exit calmly when not installed SUID root and invoked by non-root.  This
+   * allows installing user/grub-boot-success.service unconditionally while
+   * supporting non-SUID installation of the program for some limited usage.
+   */
+  if (geteuid())
+    {
+      printf ("grub-set-bootflag not running as root, no action taken\n");
+      return 0;
+    }
+
+  /*
    * setegid avoids the new grubenv's gid being that of the user.
    */
   if (setegid(0))


### PR DESCRIPTION
Update latest patches from dist-git. Patches:

Patch0347: 0347-normal-Remove-grub_env_set-prefix-in-grub_try_normal.patch
Patch0349: 0349-grub-set-bootflag-Conservative-partial-fix-for-CVE-2.patch
Patch0350: 0350-grub-set-bootflag-More-complete-fix-for-CVE-2024-104.patch
Patch0351: 0351-grub-set-bootflag-Exit-calmly-when-not-running-as-ro.patch
Patch0353: 0353-fs-ntfs-Fix-an-OOB-write-when-parsing-the-ATTRIBUTE_.patch
Patch0354: 0354-fs-ntfs-Fix-an-OOB-read-when-reading-data-from-the-r.patch
Patch0355: 0355-fs-ntfs-Fix-an-OOB-read-when-parsing-directory-entri.patch
Patch0356: 0356-fs-ntfs-Fix-an-OOB-read-when-parsing-bitmaps-for-ind.patch
Patch0357: 0357-fs-ntfs-Fix-an-OOB-read-when-parsing-a-volume-label.patch
Patch0358: 0358-fs-ntfs-Make-code-more-readable.patch
Patch0359: 0359-fs-xfs-Handle-non-continuous-data-blocks-in-director.patch

Note that the following patches were NOT applied

Patch0348: 0348-add-flag-to-only-search-root-dev.patch
Patch0352: 0352-fs-xfs-Fix-XFS-directory-extent-parsing.patch

because these are already on branch