### PR TITLE
Fedora 40 dist-git sync from Patch 0347 to Patch 0360

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2009,8 +2009,8 @@ if test x"$enable_wextra" != xno ; then
   HOST_CFLAGS="$HOST_CFLAGS -Wextra"
 fi
 
-TARGET_CFLAGS="$TARGET_CFLAGS -Werror=trampolines -fno-trampolines"
-HOST_CFLAGS="$HOST_CFLAGS -Werror=trampolines -fno-trampolines"
+TARGET_CFLAGS="$TARGET_CFLAGS -Werror=trampolines -fno-trampolines -Wno-incompatible-pointer-types"
+HOST_CFLAGS="$HOST_CFLAGS -Werror=trampolines -fno-trampolines -Wno-incompatible-pointer-types"
 
 TARGET_CPP="$TARGET_CC -E"
 TARGET_CCAS=$TARGET_CC

--- a/grub-core/commands/search.c
+++ b/grub-core/commands/search.c
@@ -87,11 +87,40 @@ iterate_device (const char *name, void *data)
     }
 
   /* Skip it if it's not the root device when requested. */
-  root_dev = grub_env_get ("root");
-  if (ctx->flags & SEARCH_FLAGS_ROOTDEV_ONLY &&
-      (name[0] != root_dev[0] || name[1] != root_dev[1] ||
-       name[2] != root_dev[2]))
-    return 0;
+  if (ctx->flags & SEARCH_FLAGS_ROOTDEV_ONLY)
+    {
+      const char *root_dev;
+      root_dev = grub_env_get ("root");
+      if (root_dev != NULL && *root_dev != '\0')
+      {
+        char *root_disk = grub_malloc (grub_strlen(root_dev) + 1);
+        char *name_disk = grub_malloc (grub_strlen(name) + 1);
+        char *rem_1 = grub_malloc(grub_strlen(root_dev) + 1);
+        char *rem_2 = grub_malloc(grub_strlen(name) + 1);
+
+	if (root_disk != NULL && name_disk != NULL && 
+	    rem_1 != NULL && rem_2 != NULL)
+  	  {
+            /* get just the disk name; partitions will be different. */
+            grub_str_sep (root_dev, root_disk, ',', rem_1);
+            grub_str_sep (name, name_disk, ',', rem_2);
+            if (root_disk != NULL && *root_disk != '\0' &&
+    	        name_disk != NULL && *name_disk != '\0')
+              if (grub_strcmp(root_disk, name_disk) != 0)
+                {
+                  grub_free (root_disk);
+                  grub_free (name_disk);
+                  grub_free (rem_1);
+                  grub_free (rem_2);
+                  return 0;
+                }
+	  }
+        grub_free (root_disk);
+        grub_free (name_disk);
+        grub_free (rem_1);
+        grub_free (rem_2);
+      }
+    }
 
 #ifdef DO_SEARCH_FS_UUID
 #define compare_fn grub_strcasecmp

--- a/grub-core/fs/xfs.c
+++ b/grub-core/fs/xfs.c
@@ -902,6 +902,7 @@ grub_xfs_iterate_dir (grub_fshelp_node_t dir,
 					grub_xfs_first_de(dir->data, dirblock);
 	    int entries = -1;
 	    char *end = dirblock + dirblk_size;
+	    grub_uint32_t magic;
 
 	    numread = grub_xfs_read_file (dir, 0, 0,
 					  blk << dirblk_log2,
@@ -911,6 +912,15 @@ grub_xfs_iterate_dir (grub_fshelp_node_t dir,
 	        grub_free (dirblock);
 	        return 0;
 	      }
+
+	    /*
+	     * If this data block isn't actually part of the extent list then
+	     * grub_xfs_read_file() returns a block of zeros. So, if the magic
+	     * number field is all zeros then this block should be skipped.
+	     */
+	    magic = *(grub_uint32_t *)(void *) dirblock;
+	    if (!magic)
+	      continue;
 
 	    /*
 	     * Leaf and tail information are only in the data block if the number

--- a/grub-core/kern/misc.c
+++ b/grub-core/kern/misc.c
@@ -619,6 +619,36 @@ grub_reverse (char *str)
     }
 }
 
+/* Separate string into two parts, broken up by delimiter delim. */
+void
+grub_str_sep (const char *s, char *p, char delim, char *r)
+{
+  char* t = grub_strndup(s, grub_strlen(s));
+
+  if (t != NULL && *t != '\0')
+  {
+    char* tmp = t;
+  
+    while (((*p = *t) != '\0') && ((*p = *t) != delim))
+    {
+      p++;
+      t++;
+    }
+    *p = '\0';
+  
+    if (*t != '\0')
+    {
+      t++;
+      while ((*r++ = *t++) != '\0')
+        ;
+      *r = '\0';
+    }
+    grub_free (tmp);
+  }
+  else
+    grub_free (t);
+}
+
 /* Divide N by D, return the quotient, and store the remainder in *R.  */
 grub_uint64_t
 grub_divmod64 (grub_uint64_t n, grub_uint64_t d, grub_uint64_t *r)

--- a/include/grub/misc.h
+++ b/include/grub/misc.h
@@ -314,6 +314,7 @@ void *EXPORT_FUNC(grub_memset) (void *s, int c, grub_size_t n);
 grub_size_t EXPORT_FUNC(grub_strlen) (const char *s) WARN_UNUSED_RESULT;
 int EXPORT_FUNC(grub_printf) (const char *fmt, ...) __attribute__ ((format (GNU_PRINTF, 1, 2)));
 int EXPORT_FUNC(grub_printf_) (const char *fmt, ...) __attribute__ ((format (GNU_PRINTF, 1, 2)));
+void EXPORT_FUNC(grub_str_sep) (const char *s, char *p, char delim, char *r);
 
 /* Replace all `ch' characters of `input' with `with' and copy the
    result into `output'; return EOS address of `output'. */


### PR DESCRIPTION
Not all dist-git patches were taken because these are already on branch. 

Note that this MR fully syncs [add-flag-to-only-search-root-dev](https://src.fedoraproject.org/rpms/grub2/blob/f40/f/0348-add-flag-to-only-search-root-dev.patch) patch.