### PR TITLE
RHEL 9.3.0 dist-git sync

### DIFF
--- a/grub-core/commands/search.c
+++ b/grub-core/commands/search.c
@@ -85,6 +85,42 @@ iterate_device (const char *name, void *data)
       grub_device_close (dev);
     }
 
+  /* Skip it if it's not the root device when requested. */
+  if (ctx->flags & SEARCH_FLAGS_ROOTDEV_ONLY)
+    {
+      const char *root_dev;
+      root_dev = grub_env_get ("root");
+      if (root_dev != NULL && *root_dev != '\0')
+      {
+        char *root_disk = grub_malloc (grub_strlen(root_dev) + 1);
+        char *name_disk = grub_malloc (grub_strlen(name) + 1);
+        char *rem_1 = grub_malloc(grub_strlen(root_dev) + 1);
+        char *rem_2 = grub_malloc(grub_strlen(name) + 1);
+
+	if (root_disk != NULL && name_disk != NULL &&
+	    rem_1 != NULL && rem_2 != NULL)
+     {
+            /* get just the disk name; partitions will be different. */
+            grub_str_sep (root_dev, root_disk, ',', rem_1);
+            grub_str_sep (name, name_disk, ',', rem_2);
+            if (root_disk != NULL && *root_disk != '\0' &&
+             name_disk != NULL && *name_disk != '\0')
+              if (grub_strcmp(root_disk, name_disk) != 0)
+                {
+                  grub_free (root_disk);
+                  grub_free (name_disk);
+                  grub_free (rem_1);
+                  grub_free (rem_2);
+                  return 0;
+                }
+	  }
+        grub_free (root_disk);
+        grub_free (name_disk);
+        grub_free (rem_1);
+        grub_free (rem_2);
+      }
+    }
+
 #ifdef DO_SEARCH_FS_UUID
 #define compare_fn grub_strcasecmp
 #else

--- a/grub-core/commands/search_wrap.c
+++ b/grub-core/commands/search_wrap.c
@@ -41,6 +41,7 @@ static const struct grub_arg_option options[] =
      ARG_TYPE_STRING},
     {"no-floppy",	'n', 0, N_("Do not probe any floppy drive."), 0, 0},
     {"efidisk-only",	0, 0, N_("Only probe EFI disks."), 0, 0},
+    {"root-dev-only",  'r', 0, N_("Only probe root device."), 0, 0},
     {"hint",	        'h', GRUB_ARG_OPTION_REPEATABLE,
      N_("First try the device HINT. If HINT ends in comma, "
 	"also try subpartitions"), N_("HINT"), ARG_TYPE_STRING},
@@ -75,6 +76,7 @@ enum options
     SEARCH_SET,
     SEARCH_NO_FLOPPY,
     SEARCH_EFIDISK_ONLY,
+    SEARCH_ROOTDEV_ONLY,
     SEARCH_HINT,
     SEARCH_HINT_IEEE1275,
     SEARCH_HINT_BIOS,
@@ -188,6 +190,9 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
 
   if (state[SEARCH_EFIDISK_ONLY].set)
     flags |= SEARCH_FLAGS_EFIDISK_ONLY;
+
+  if (state[SEARCH_ROOTDEV_ONLY].set)
+    flags |= SEARCH_FLAGS_ROOTDEV_ONLY;
 
   if (state[SEARCH_LABEL].set)
     grub_search_label (id, var, flags, hints, nhints);

--- a/grub-core/kern/misc.c
+++ b/grub-core/kern/misc.c
@@ -619,6 +619,36 @@ grub_reverse (char *str)
     }
 }
 
+/* Separate string into two parts, broken up by delimiter delim. */
+void
+grub_str_sep (const char *s, char *p, char delim, char *r)
+{
+  char* t = grub_strndup(s, grub_strlen(s));
+
+  if (t != NULL && *t != '\0')
+  {
+    char* tmp = t;
+
+    while (((*p = *t) != '\0') && ((*p = *t) != delim))
+    {
+      p++;
+      t++;
+    }
+    *p = '\0';
+
+    if (*t != '\0')
+    {
+      t++;
+      while ((*r++ = *t++) != '\0')
+        ;
+      *r = '\0';
+    }
+    grub_free (tmp);
+  }
+  else
+    grub_free (t);
+}
+
 /* Divide N by D, return the quotient, and store the remainder in *R.  */
 grub_uint64_t
 grub_divmod64 (grub_uint64_t n, grub_uint64_t d, grub_uint64_t *r)

--- a/grub-core/normal/main.c
+++ b/grub-core/normal/main.c
@@ -372,7 +372,6 @@ grub_try_normal_prefix (const char *prefix)
            file = grub_file_open (config, GRUB_FILE_TYPE_CONFIG);
            if (file)
              {
-               grub_env_set ("prefix", prefix);
                grub_file_close (file);
                err = GRUB_ERR_NONE;
              }

--- a/include/grub/misc.h
+++ b/include/grub/misc.h
@@ -314,6 +314,7 @@ void *EXPORT_FUNC(grub_memset) (void *s, int c, grub_size_t n);
 grub_size_t EXPORT_FUNC(grub_strlen) (const char *s) WARN_UNUSED_RESULT;
 int EXPORT_FUNC(grub_printf) (const char *fmt, ...) __attribute__ ((format (GNU_PRINTF, 1, 2)));
 int EXPORT_FUNC(grub_printf_) (const char *fmt, ...) __attribute__ ((format (GNU_PRINTF, 1, 2)));
+void EXPORT_FUNC(grub_str_sep) (const char *s, char *p, char delim, char *r);
 
 /* Replace all `ch' characters of `input' with `with' and copy the
    result into `output'; return EOS address of `output'. */

--- a/include/grub/search.h
+++ b/include/grub/search.h
@@ -22,7 +22,8 @@
 enum search_flags
   {
     SEARCH_FLAGS_NO_FLOPPY	= 1,
-    SEARCH_FLAGS_EFIDISK_ONLY	= 2
+    SEARCH_FLAGS_EFIDISK_ONLY	= 2,
+    SEARCH_FLAGS_ROOTDEV_ONLY	= 4
   };
 
 void grub_search_fs_file (const char *key, const char *var,

--- a/util/grub-mkconfig.in
+++ b/util/grub-mkconfig.in
@@ -51,6 +51,7 @@ export TEXTDOMAIN=@PACKAGE@
 export TEXTDOMAINDIR="@localedir@"
 
 export GRUB_GRUBENV_UPDATE="yes"
+export GRUB_UPDATE_BLS_CMDLINE="yes"
 
 . "${pkgdatadir}/grub-mkconfig_lib"
 
@@ -62,6 +63,7 @@ usage () {
     echo
     print_option_help "-o, --output=$(gettext FILE)" "$(gettext "output generated config to FILE [default=stdout]")"
     print_option_help "--no-grubenv-update" "$(gettext "do not update variables in the grubenv file")"
+    print_option_help "--update-bls-cmdline" "$(gettext "overwrite BLS cmdline args with default args")"
     print_option_help "-h, --help" "$(gettext "print this message and exit")"
     print_option_help "-V, --version" "$(gettext "print the version information and exit")"
     echo
@@ -99,6 +101,9 @@ do
 	;;
     --no-grubenv-update)
 	GRUB_GRUBENV_UPDATE="no"
+	;;
+    --update-bls-cmdline)
+	bls_cmdline_update=true
 	;;
     -*)
 	gettext_printf "Unrecognized option \`%s'\n" "$option" 1>&2
@@ -166,6 +171,11 @@ if test -f ${sysconfdir}/default/grub ; then
 fi
 
 eval "$("${grub_get_kernel_settings}")" || true
+
+if [ "x${GRUB_ENABLE_BLSCFG}" = "xtrue" ] && \
+	[ "x${bls_cmdline_update}" != "xtrue" ]; then
+    GRUB_UPDATE_BLS_CMDLINE="no"
+fi
 
 if [ "x${GRUB_DISABLE_UUID}" = "xtrue" ]; then
   if [ -z "${GRUB_DISABLE_LINUX_UUID}" ]; then

--- a/util/grub.d/10_linux.in
+++ b/util/grub.d/10_linux.in
@@ -265,7 +265,9 @@ if [ -z "\${kernelopts}" ]; then
 fi
 EOF
 
-  if [ "x${GRUB_GRUBENV_UPDATE}" = "xyes" ]; then
+  if [ "x${GRUB_UPDATE_BLS_CMDLINE}" = "xyes" ] || \
+	  ( [ -w /etc/kernel ] && [[ ! -f /etc/kernel/cmdline ]] && \
+	  [ "x${GRUB_GRUBENV_UPDATE}" = "xyes" ] ); then
       update_bls_cmdline
   fi
 

--- a/util/grub.d/10_linux.in
+++ b/util/grub.d/10_linux.in
@@ -265,9 +265,11 @@ if [ -z "\${kernelopts}" ]; then
 fi
 EOF
 
-  if [ "x${GRUB_UPDATE_BLS_CMDLINE}" = "xyes" ] || \
-	  ( [ -w /etc/kernel ] && [[ ! -f /etc/kernel/cmdline ]] && \
-	  [ "x${GRUB_GRUBENV_UPDATE}" = "xyes" ] ); then
+  if [ "x${GRUB_UPDATE_BLS_CMDLINE}" = "xyes" ] || [[ -d /run/install ]]; then
+      # only update the bls cmdline if the user specifically requests it or _anytime_
+      # in the installer environment: /run/install directory only exists during the
+      # installation and not in cloud images, so this should get all the boot params
+      # from /etc/default/grub into BLS snippets
       update_bls_cmdline
   fi
 


### PR DESCRIPTION
The following dist-git patches were applied

APPLIED: 0327-grub-mkconfig-dont-overwrite-BLS-cmdline-if-BLSCFG.patch
APPLIED: 0328-grub2-mkconfig-Pass-all-boot-params-when-used-by-ana.patch
APPLIED: 0329-search-command-add-flag-to-only-search-root-dev.patch
APPLIED: 0330-normal-Remove-grub_env_set-prefix-in-grub_try_normal.patch
