### PR TITLE
grub-mkconfig.in: turn off executable owner bit

### DIFF
--- a/util/grub-mkconfig.in
+++ b/util/grub-mkconfig.in
@@ -317,7 +317,7 @@ and /etc/grub.d/* files or please file a bug report with
     exit 1
   else
     # none of the children aborted with error, install the new grub.cfg
-    oldumask=$(umask); umask 077
+    oldumask=$(umask); umask 177
     cat ${grub_cfg}.new > ${grub_cfg}
     umask $oldumask
     rm -f ${grub_cfg}.new


### PR DESCRIPTION
Stricker permissions are required on the grub.cfg file, resulting in at most 0600 owner's file permissions. This resolves conflicting requirement permissions on grub2-pc package's grub2.cfg file.

Resolves: #RHEL-16478