### PR TITLE
RHEL 9.4.0 dist-git sync

### DIFF
--- a/grub-core/commands/search.c
+++ b/grub-core/commands/search.c
@@ -85,6 +85,42 @@ iterate_device (const char *name, void *data)
       grub_device_close (dev);
     }
 
+  /* Skip it if it's not the root device when requested. */
+  if (ctx->flags & SEARCH_FLAGS_ROOTDEV_ONLY)
+    {
+      const char *root_dev;
+      root_dev = grub_env_get ("root");
+      if (root_dev != NULL && *root_dev != '\0')
+      {
+        char *root_disk = grub_malloc (grub_strlen(root_dev) + 1);
+        char *name_disk = grub_malloc (grub_strlen(name) + 1);
+        char *rem_1 = grub_malloc(grub_strlen(root_dev) + 1);
+        char *rem_2 = grub_malloc(grub_strlen(name) + 1);
+
+	if (root_disk != NULL && name_disk != NULL &&
+	    rem_1 != NULL && rem_2 != NULL)
+     {
+            /* get just the disk name; partitions will be different. */
+            grub_str_sep (root_dev, root_disk, ',', rem_1);
+            grub_str_sep (name, name_disk, ',', rem_2);
+            if (root_disk != NULL && *root_disk != '\0' &&
+             name_disk != NULL && *name_disk != '\0')
+              if (grub_strcmp(root_disk, name_disk) != 0)
+                {
+                  grub_free (root_disk);
+                  grub_free (name_disk);
+                  grub_free (rem_1);
+                  grub_free (rem_2);
+                  return 0;
+                }
+	  }
+        grub_free (root_disk);
+        grub_free (name_disk);
+        grub_free (rem_1);
+        grub_free (rem_2);
+      }
+    }
+
 #ifdef DO_SEARCH_FS_UUID
 #define compare_fn grub_strcasecmp
 #else

--- a/grub-core/commands/search_wrap.c
+++ b/grub-core/commands/search_wrap.c
@@ -41,6 +41,7 @@ static const struct grub_arg_option options[] =
      ARG_TYPE_STRING},
     {"no-floppy",	'n', 0, N_("Do not probe any floppy drive."), 0, 0},
     {"efidisk-only",	0, 0, N_("Only probe EFI disks."), 0, 0},
+    {"root-dev-only",  'r', 0, N_("Only probe root device."), 0, 0},
     {"hint",	        'h', GRUB_ARG_OPTION_REPEATABLE,
      N_("First try the device HINT. If HINT ends in comma, "
 	"also try subpartitions"), N_("HINT"), ARG_TYPE_STRING},
@@ -75,6 +76,7 @@ enum options
     SEARCH_SET,
     SEARCH_NO_FLOPPY,
     SEARCH_EFIDISK_ONLY,
+    SEARCH_ROOTDEV_ONLY,
     SEARCH_HINT,
     SEARCH_HINT_IEEE1275,
     SEARCH_HINT_BIOS,
@@ -188,6 +190,9 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
 
   if (state[SEARCH_EFIDISK_ONLY].set)
     flags |= SEARCH_FLAGS_EFIDISK_ONLY;
+
+  if (state[SEARCH_ROOTDEV_ONLY].set)
+    flags |= SEARCH_FLAGS_ROOTDEV_ONLY;
 
   if (state[SEARCH_LABEL].set)
     grub_search_label (id, var, flags, hints, nhints);

--- a/grub-core/fs/ntfs.c
+++ b/grub-core/fs/ntfs.c
@@ -839,6 +839,25 @@ grub_ntfs_iterate_dir (grub_fshelp_node_t dir,
 
 	  if (is_resident)
 	    {
+              if (bitmap_len > (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR))
+		{
+		  grub_error (GRUB_ERR_BAD_FS, "resident bitmap too large");
+		  goto done;
+		}
+
+              if (cur_pos >= at->mft->buf + (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR))
+		{
+		  grub_error (GRUB_ERR_BAD_FS, "resident bitmap out of range");
+		  goto done;
+		}
+
+              if (u16at (cur_pos, 0x14) + u32at (cur_pos, 0x10) >
+		  (grub_addr_t) at->mft->buf + (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR) - (grub_addr_t) cur_pos)
+		{
+		  grub_error (GRUB_ERR_BAD_FS, "resident bitmap out of range");
+		  goto done;
+		}
+
               grub_memcpy (bmp, cur_pos + u16at (cur_pos, 0x14),
                            bitmap_len);
 	    }

--- a/grub-core/fs/ntfs.c
+++ b/grub-core/fs/ntfs.c
@@ -52,6 +52,24 @@ u64at (void *ptr, grub_size_t ofs)
   return grub_le_to_cpu64 (grub_get_unaligned64 ((char *) ptr + ofs));
 }
 
+static grub_uint16_t
+first_attr_off (void *mft_buf_ptr)
+{
+  return u16at (mft_buf_ptr, 0x14);
+}
+
+static grub_uint16_t
+res_attr_data_off (void *res_attr_ptr)
+{
+  return u16at (res_attr_ptr, 0x14);
+}
+
+static grub_uint32_t
+res_attr_data_len (void *res_attr_ptr)
+{
+  return u32at (res_attr_ptr, 0x10);
+}
+
 grub_ntfscomp_func_t grub_ntfscomp_func;
 
 static grub_err_t
@@ -106,7 +124,7 @@ init_attr (struct grub_ntfs_attr *at, struct grub_ntfs_file *mft)
 {
   at->mft = mft;
   at->flags = (mft == &mft->data->mmft) ? GRUB_NTFS_AF_MMFT : 0;
-  at->attr_nxt = mft->buf + u16at (mft->buf, 0x14);
+  at->attr_nxt = mft->buf + first_attr_off (mft->buf);
   at->attr_end = at->emft_buf = at->edat_buf = at->sbuf = NULL;
 }
 
@@ -154,7 +172,7 @@ find_attr (struct grub_ntfs_attr *at, grub_uint8_t attr)
 		    return NULL;
 		}
 
-	      new_pos = &at->emft_buf[u16at (at->emft_buf, 0x14)];
+	      new_pos = &at->emft_buf[first_attr_off (at->emft_buf)];
 	      while (*new_pos != 0xFF)
 		{
 		  if ((*new_pos == *at->attr_cur)
@@ -213,7 +231,7 @@ find_attr (struct grub_ntfs_attr *at, grub_uint8_t attr)
 	}
       else
 	{
-	  at->attr_nxt = at->attr_end + u16at (pa, 0x14);
+	  at->attr_nxt = at->attr_end + res_attr_data_off (pa);
 	  at->attr_end = at->attr_end + u32at (pa, 4);
 	  pa_end = at->mft->buf + (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR);
 	}
@@ -399,20 +417,20 @@ read_data (struct grub_ntfs_attr *at, grub_uint8_t *pa, grub_uint8_t *dest,
 
   if (pa[8] == 0)
     {
-      if (ofs + len > u32at (pa, 0x10))
+      if (ofs + len > res_attr_data_len (pa))
 	return grub_error (GRUB_ERR_BAD_FS, "read out of range");
 
-      if (u32at (pa, 0x10) > (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR))
+      if (res_attr_data_len (pa) > (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR))
 	return grub_error (GRUB_ERR_BAD_FS, "resident attribute too large");
 
       if (pa >= at->mft->buf + (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR))
 	return grub_error (GRUB_ERR_BAD_FS, "resident attribute out of range");
 
-      if (u16at (pa, 0x14) + u32at (pa, 0x10) >
+      if (res_attr_data_off (pa) + res_attr_data_len (pa) >
 	  (grub_addr_t) at->mft->buf + (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR) - (grub_addr_t) pa)
 	return grub_error (GRUB_ERR_BAD_FS, "resident attribute out of range");
 
-      grub_memcpy (dest, pa + u16at (pa, 0x14) + ofs, len);
+      grub_memcpy (dest, pa + res_attr_data_off (pa) + ofs, len);
       return 0;
     }
 
@@ -556,7 +574,7 @@ init_file (struct grub_ntfs_file *mft, grub_uint64_t mftno)
 			   (unsigned long long) mftno);
 
       if (!pa[8])
-	mft->size = u32at (pa, 0x10);
+	mft->size = res_attr_data_len (pa);
       else
 	mft->size = u64at (pa, 0x30);
 
@@ -801,7 +819,7 @@ grub_ntfs_iterate_dir (grub_fshelp_node_t dir,
 	  (u32at (cur_pos, 0x18) != 0x490024) ||
 	  (u32at (cur_pos, 0x1C) != 0x300033))
 	continue;
-      cur_pos += u16at (cur_pos, 0x14);
+      cur_pos += res_attr_data_off (cur_pos);
       if (*cur_pos != 0x30)	/* Not filename index */
 	continue;
       break;
@@ -830,7 +848,7 @@ grub_ntfs_iterate_dir (grub_fshelp_node_t dir,
 	{
           int is_resident = (cur_pos[8] == 0);
 
-          bitmap_len = ((is_resident) ? u32at (cur_pos, 0x10) :
+          bitmap_len = ((is_resident) ? res_attr_data_len (cur_pos) :
                         u32at (cur_pos, 0x28));
 
           bmp = grub_malloc (bitmap_len);
@@ -851,14 +869,14 @@ grub_ntfs_iterate_dir (grub_fshelp_node_t dir,
 		  goto done;
 		}
 
-              if (u16at (cur_pos, 0x14) + u32at (cur_pos, 0x10) >
+              if (res_attr_data_off (cur_pos) + res_attr_data_len (cur_pos) >
 		  (grub_addr_t) at->mft->buf + (at->mft->data->mft_size << GRUB_NTFS_BLK_SHR) - (grub_addr_t) cur_pos)
 		{
 		  grub_error (GRUB_ERR_BAD_FS, "resident bitmap out of range");
 		  goto done;
 		}
 
-              grub_memcpy (bmp, cur_pos + u16at (cur_pos, 0x14),
+              grub_memcpy (bmp, cur_pos + res_attr_data_off (cur_pos),
                            bitmap_len);
 	    }
           else
@@ -1222,12 +1240,12 @@ grub_ntfs_label (grub_device_t device, char **label)
       goto fail;
     }
 
-  if ((pa) && (pa[8] == 0) && (u32at (pa, 0x10)))
+  if ((pa) && (pa[8] == 0) && (res_attr_data_len (pa)))
     {
       int len;
 
-      len = u32at (pa, 0x10) / 2;
-      pa += u16at (pa, 0x14);
+      len = res_attr_data_len (pa) / 2;
+      pa += res_attr_data_off (pa);
       if (mft->buf + (mft->data->mft_size << GRUB_NTFS_BLK_SHR) - pa >= 2 * len)
         *label = get_utf8 (pa, len);
       else

--- a/grub-core/kern/dl.c
+++ b/grub-core/kern/dl.c
@@ -733,7 +733,8 @@ grub_dl_set_mem_attrs (grub_dl_t mod, void *ehdr)
     {
       tgsz = ALIGN_UP(tgsz, arch_addralign);
 
-      grub_dprintf ("modules", "updating attributes for GOT and trampolines\n",
+      grub_dprintf ("modules",
+		    "updating attributes for GOT and trampolines (\"%s\")\n",
 		    mod->name);
       grub_update_mem_attrs (tgaddr, tgsz, GRUB_MEM_ATTR_R|GRUB_MEM_ATTR_X,
 			     GRUB_MEM_ATTR_W);

--- a/grub-core/kern/dl.c
+++ b/grub-core/kern/dl.c
@@ -280,7 +280,9 @@ grub_dl_load_segments (grub_dl_t mod, const Elf_Ehdr *e)
   grub_size_t tsize = 0, talign = 1, arch_addralign = 1;
 #if !defined (__i386__) && !defined (__x86_64__) && !defined(__riscv)
   grub_size_t tramp;
+  grub_size_t tramp_align;
   grub_size_t got;
+  grub_size_t got_align;
   grub_err_t err;
 #endif
   char *ptr;
@@ -311,12 +313,18 @@ grub_dl_load_segments (grub_dl_t mod, const Elf_Ehdr *e)
   err = grub_arch_dl_get_tramp_got_size (e, &tramp, &got);
   if (err)
     return err;
-  tsize += ALIGN_UP (tramp, GRUB_ARCH_DL_TRAMP_ALIGN);
-  if (talign < GRUB_ARCH_DL_TRAMP_ALIGN)
-    talign = GRUB_ARCH_DL_TRAMP_ALIGN;
-  tsize += ALIGN_UP (got, GRUB_ARCH_DL_GOT_ALIGN);
-  if (talign < GRUB_ARCH_DL_GOT_ALIGN)
-    talign = GRUB_ARCH_DL_GOT_ALIGN;
+  tramp_align = GRUB_ARCH_DL_TRAMP_ALIGN;
+  if (tramp_align < arch_addralign)
+    tramp_align = arch_addralign;
+  tsize += ALIGN_UP (tramp, tramp_align);
+  if (talign < tramp_align)
+    talign = tramp_align;
+  got_align = GRUB_ARCH_DL_GOT_ALIGN;
+  if (got_align < arch_addralign)
+    got_align = arch_addralign;
+  tsize += ALIGN_UP (got, got_align);
+  if (talign < got_align)
+    talign = got_align;
 #endif
 
 #ifdef GRUB_MACHINE_EMU
@@ -376,11 +384,11 @@ grub_dl_load_segments (grub_dl_t mod, const Elf_Ehdr *e)
 	}
     }
 #if !defined (__i386__) && !defined (__x86_64__) && !defined(__riscv)
-  ptr = (char *) ALIGN_UP ((grub_addr_t) ptr, GRUB_ARCH_DL_TRAMP_ALIGN);
+  ptr = (char *) ALIGN_UP ((grub_addr_t) ptr, tramp_align);
   mod->tramp = ptr;
   mod->trampptr = ptr;
   ptr += tramp;
-  ptr = (char *) ALIGN_UP ((grub_addr_t) ptr, GRUB_ARCH_DL_GOT_ALIGN);
+  ptr = (char *) ALIGN_UP ((grub_addr_t) ptr, got_align);
   mod->got = ptr;
   mod->gotptr = ptr;
   ptr += got;

--- a/grub-core/kern/ieee1275/init.c
+++ b/grub-core/kern/ieee1275/init.c
@@ -17,6 +17,8 @@
  *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stddef.h> /* offsetof() */
+
 #include <grub/kernel.h>
 #include <grub/dl.h>
 #include <grub/disk.h>
@@ -198,6 +200,96 @@ grub_claim_heap (void)
 #else
 /* Helpers for mm on powerpc. */
 
+/* ibm,kernel-dump data structures */
+struct kd_section
+{
+  grub_uint32_t flags;
+  grub_uint16_t src_datatype;
+#define KD_SRC_DATATYPE_REAL_MODE_REGION  0x0011
+  grub_uint16_t error_flags;
+  grub_uint64_t src_address;
+  grub_uint64_t num_bytes;
+  grub_uint64_t act_bytes;
+  grub_uint64_t dst_address;
+} GRUB_PACKED;
+
+#define MAX_KD_SECTIONS 10
+
+struct kernel_dump
+{
+  grub_uint32_t format;
+  grub_uint16_t num_sections;
+  grub_uint16_t status_flags;
+  grub_uint32_t offset_1st_section;
+  grub_uint32_t num_blocks;
+  grub_uint64_t start_block;
+  grub_uint64_t num_blocks_avail;
+  grub_uint32_t offet_path_string;
+  grub_uint32_t max_time_allowed;
+  struct kd_section kds[MAX_KD_SECTIONS]; /* offset_1st_section should point to kds[0] */
+} GRUB_PACKED;
+
+/*
+ * Determine if a kernel dump exists and if it does, then determine the highest
+ * address that grub can use for memory allocations.
+ * The caller must have initialized *highest to rmo_top. *highest will not
+ * be modified if no kernel dump is found.
+ */
+static void
+check_kernel_dump (grub_uint64_t *highest)
+{
+  struct kernel_dump kernel_dump;
+  grub_ssize_t kernel_dump_size;
+  grub_ieee1275_phandle_t rtas;
+  struct kd_section *kds;
+  grub_size_t i;
+
+  /* If there's a kernel-dump it must have at least one section */
+  if (grub_ieee1275_finddevice ("/rtas", &rtas) ||
+      grub_ieee1275_get_property (rtas, "ibm,kernel-dump", &kernel_dump,
+                                  sizeof (kernel_dump), &kernel_dump_size) ||
+      kernel_dump_size <= (grub_ssize_t) offsetof (struct kernel_dump, kds[1]))
+    return;
+
+  kernel_dump_size = grub_min (kernel_dump_size, (grub_ssize_t) sizeof (kernel_dump));
+
+  if (grub_be_to_cpu32 (kernel_dump.format) != 1)
+    {
+      grub_printf (_("Error: ibm,kernel-dump has an unexpected format version '%u'\n"),
+                   grub_be_to_cpu32 (kernel_dump.format));
+      return;
+    }
+
+  if (grub_be_to_cpu16 (kernel_dump.num_sections) > MAX_KD_SECTIONS)
+    {
+      grub_printf (_("Error: Too many kernel dump sections: %d\n"),
+                   grub_be_to_cpu32 (kernel_dump.num_sections));
+      return;
+    }
+
+  for (i = 0; i < grub_be_to_cpu16 (kernel_dump.num_sections); i++)
+    {
+      kds = (struct kd_section *) ((grub_addr_t) &kernel_dump +
+                                   grub_be_to_cpu32 (kernel_dump.offset_1st_section) +
+                                   i * sizeof (struct kd_section));
+      /* sanity check the address is within the 'kernel_dump' struct */
+      if ((grub_addr_t) kds > (grub_addr_t) &kernel_dump + kernel_dump_size + sizeof (*kds))
+        {
+          grub_printf (_("Error: 'kds' address beyond last available section\n"));
+          return;
+        }
+
+      if ((grub_be_to_cpu16 (kds->src_datatype) == KD_SRC_DATATYPE_REAL_MODE_REGION) &&
+          (grub_be_to_cpu64 (kds->src_address) == 0))
+        {
+          *highest = grub_min (*highest, grub_be_to_cpu64 (kds->num_bytes));
+          break;
+        }
+    }
+
+  return;
+}
+
 /*
  * How much memory does OF believe exists in total?
  *
@@ -277,9 +369,30 @@ regions_claim (grub_uint64_t addr, grub_uint64_t len, grub_memory_type_t type,
    *
    * Finally, we also want to make sure that when grub loads the kernel,
    * it isn't going to use up all the memory we're trying to reserve! So
-   * enforce our entire RUNTIME_MIN_SPACE here:
+   * enforce our entire RUNTIME_MIN_SPACE here (no fadump):
+   *
+   * | Top of memory == upper_mem_limit -|
+   * |                                   |
+   * |             available             |
+   * |                                   |
+   * |----------     768 MB    ----------|
+   * |                                   |
+   * |              reserved             |
+   * |                                   |
+   * |--- 768 MB - runtime min space  ---|
+   * |                                   |
+   * |             available             |
+   * |                                   |
+   * |----------      0 MB     ----------|
+   *
+   * In case fadump is used, we allow the following:
    *
    * |---------- Top of memory ----------|
+   * |                                   |
+   * |             unavailable           |
+   * |         (kernel dump area)        |
+   * |                                   |
+   * |--------- upper_mem_limit ---------|
    * |                                   |
    * |             available             |
    * |                                   |
@@ -335,17 +448,44 @@ regions_claim (grub_uint64_t addr, grub_uint64_t len, grub_memory_type_t type,
         }
       else
         {
+          grub_uint64_t upper_mem_limit = rmo_top;
+          grub_uint64_t orig_addr = addr;
+
+          check_kernel_dump (&upper_mem_limit);
+
           /*
            * we order these cases to prefer higher addresses and avoid some
            * splitting issues
+           * The following shows the order of variables:
+           *  no   kernel dump: linux_rmo_save < RMO_ADDR_MAX <= upper_mem_limit == rmo_top
+           *  with kernel dump: liuxx_rmo_save < RMO_ADDR_MAX <= upper_mem_limit <= rmo_top
            */
-          if (addr < RMO_ADDR_MAX && (addr + len) > RMO_ADDR_MAX)
+          if (addr < RMO_ADDR_MAX && (addr + len) > RMO_ADDR_MAX && upper_mem_limit >= RMO_ADDR_MAX)
             {
               grub_dprintf ("ieee1275",
                             "adjusting region for RUNTIME_MIN_SPACE: (%llx -> %llx) -> (%llx -> %llx)\n",
                             addr, addr + len, RMO_ADDR_MAX, addr + len);
               len = (addr + len) - RMO_ADDR_MAX;
               addr = RMO_ADDR_MAX;
+
+              /* We must not exceed the upper_mem_limit (assuming it's >= RMO_ADDR_MAX) */
+              if (addr + len > upper_mem_limit)
+                {
+                  /* take the bigger chunk from either below linux_rmo_save or above upper_mem_limit */
+                  len = upper_mem_limit - addr;
+                  if (orig_addr < linux_rmo_save && linux_rmo_save - orig_addr > len)
+                    {
+                      /* lower part is bigger */
+                      addr = orig_addr;
+                      len = linux_rmo_save - addr;
+                    }
+
+                  grub_dprintf ("ieee1275", "re-adjusted region to: (%llx -> %llx)\n",
+                                addr, addr + len);
+
+                  if (len == 0)
+                    return 0;
+                }
             }
           else if ((addr < linux_rmo_save) && ((addr + len) > linux_rmo_save))
             {

--- a/grub-core/kern/misc.c
+++ b/grub-core/kern/misc.c
@@ -619,6 +619,36 @@ grub_reverse (char *str)
     }
 }
 
+/* Separate string into two parts, broken up by delimiter delim. */
+void
+grub_str_sep (const char *s, char *p, char delim, char *r)
+{
+  char* t = grub_strndup(s, grub_strlen(s));
+
+  if (t != NULL && *t != '\0')
+  {
+    char* tmp = t;
+
+    while (((*p = *t) != '\0') && ((*p = *t) != delim))
+    {
+      p++;
+      t++;
+    }
+    *p = '\0';
+
+    if (*t != '\0')
+    {
+      t++;
+      while ((*r++ = *t++) != '\0')
+        ;
+      *r = '\0';
+    }
+    grub_free (tmp);
+  }
+  else
+    grub_free (t);
+}
+
 /* Divide N by D, return the quotient, and store the remainder in *R.  */
 grub_uint64_t
 grub_divmod64 (grub_uint64_t n, grub_uint64_t d, grub_uint64_t *r)

--- a/grub-core/normal/main.c
+++ b/grub-core/normal/main.c
@@ -372,7 +372,6 @@ grub_try_normal_prefix (const char *prefix)
            file = grub_file_open (config, GRUB_FILE_TYPE_CONFIG);
            if (file)
              {
-               grub_env_set ("prefix", prefix);
                grub_file_close (file);
                err = GRUB_ERR_NONE;
              }

--- a/include/grub/misc.h
+++ b/include/grub/misc.h
@@ -314,6 +314,7 @@ void *EXPORT_FUNC(grub_memset) (void *s, int c, grub_size_t n);
 grub_size_t EXPORT_FUNC(grub_strlen) (const char *s) WARN_UNUSED_RESULT;
 int EXPORT_FUNC(grub_printf) (const char *fmt, ...) __attribute__ ((format (GNU_PRINTF, 1, 2)));
 int EXPORT_FUNC(grub_printf_) (const char *fmt, ...) __attribute__ ((format (GNU_PRINTF, 1, 2)));
+void EXPORT_FUNC(grub_str_sep) (const char *s, char *p, char delim, char *r);
 
 /* Replace all `ch' characters of `input' with `with' and copy the
    result into `output'; return EOS address of `output'. */

--- a/include/grub/search.h
+++ b/include/grub/search.h
@@ -22,7 +22,8 @@
 enum search_flags
   {
     SEARCH_FLAGS_NO_FLOPPY	= 1,
-    SEARCH_FLAGS_EFIDISK_ONLY	= 2
+    SEARCH_FLAGS_EFIDISK_ONLY	= 2,
+    SEARCH_FLAGS_ROOTDEV_ONLY	= 4
   };
 
 void grub_search_fs_file (const char *key, const char *var,

--- a/util/grub-install.c
+++ b/util/grub-install.c
@@ -899,22 +899,6 @@ main (int argc, char *argv[])
 
   platform = grub_install_get_target (grub_install_source_directory);
 
-  switch (platform)
-    {
-    case GRUB_INSTALL_PLATFORM_ARM_EFI:
-    case GRUB_INSTALL_PLATFORM_ARM64_EFI:
-    case GRUB_INSTALL_PLATFORM_I386_EFI:
-    case GRUB_INSTALL_PLATFORM_IA64_EFI:
-    case GRUB_INSTALL_PLATFORM_X86_64_EFI:
-      is_efi = 1;
-      grub_util_error (_("this utility cannot be used for EFI platforms"
-                         " because it does not support UEFI Secure Boot"));
-      break;
-    default:
-      is_efi = 0;
-      break;
-    }
-
   {
     char *platname = grub_install_get_platform_name (platform);
     fprintf (stderr, _("Installing for %s platform.\n"), platname);
@@ -1026,6 +1010,32 @@ main (int argc, char *argv[])
   grub_gcry_init_all ();
   grub_hostfs_init ();
   grub_host_init ();
+
+  switch (platform)
+    {
+    case GRUB_INSTALL_PLATFORM_I386_EFI:
+    case GRUB_INSTALL_PLATFORM_X86_64_EFI:
+    case GRUB_INSTALL_PLATFORM_ARM_EFI:
+    case GRUB_INSTALL_PLATFORM_ARM64_EFI:
+    case GRUB_INSTALL_PLATFORM_RISCV32_EFI:
+    case GRUB_INSTALL_PLATFORM_RISCV64_EFI:
+    case GRUB_INSTALL_PLATFORM_IA64_EFI:
+      is_efi = 1;
+      if (!force)
+        grub_util_error (_("This utility should not be used for EFI platforms"
+                          " because it does not support UEFI Secure Boot."
+                          " If you really wish to proceed, invoke the --force"
+                          " option.\nMake sure Secure Boot is disabled before"
+                          " proceeding"));
+      break;
+    default:
+      is_efi = 0;
+      break;
+
+      /* pacify warning.  */
+    case GRUB_INSTALL_PLATFORM_MAX:
+      break;
+    }
 
   /* Find the EFI System Partition.  */
   if (is_efi)

--- a/util/grub-set-bootflag.c
+++ b/util/grub-set-bootflag.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/resource.h>
 
@@ -60,15 +61,12 @@ int main(int argc, char *argv[])
 {
   /* NOTE buf must be at least the longest bootflag length + 4 bytes */
   char env[GRUBENV_SIZE + 1 + 2], buf[64], *s;
-  /* +1 for 0 termination, +6 for "XXXXXX" in tmp filename */
-  char env_filename[PATH_MAX + 1], tmp_filename[PATH_MAX + 6 + 1];
+  /* +1 for 0 termination, +11 for ".%u" in tmp filename */
+  char env_filename[PATH_MAX + 1], tmp_filename[PATH_MAX + 11 + 1];
   const char *bootflag;
   int i, fd, len, ret;
   FILE *f;
-  struct rlimit rlim;
 
-  if (getrlimit(RLIMIT_FSIZE, &rlim) || rlim.rlim_cur < GRUBENV_SIZE || rlim.rlim_max < GRUBENV_SIZE)
-    return 1;
   umask(077);
 
   if (argc != 2)
@@ -105,7 +103,7 @@ int main(int argc, char *argv[])
    */
   if (setegid(0))
     {
-      perror ("Error setegid(0) failed");
+      perror ("setegid(0) failed");
       return 1;
     }
 
@@ -176,18 +174,81 @@ int main(int argc, char *argv[])
     return 0; /* nothing to do */
   memcpy(s, buf, len + 3);
 
+  struct rlimit rlim;
+  if (getrlimit(RLIMIT_FSIZE, &rlim) || rlim.rlim_cur < GRUBENV_SIZE || rlim.rlim_max < GRUBENV_SIZE)
+    {
+      fprintf (stderr, "Resource limits undetermined or too low\n");
+      return 1;
+    }
+
+  /*
+   * Here we work under the premise that we shouldn't write into the target
+   * file directly because we might not be able to have all of our changes
+   * written completely and atomically.  That was CVE-2019-14865, known to
+   * have been triggerable via RLIMIT_FSIZE.  While we've dealt with that
+   * specific attack via the check above, there may be other possibilities.
+   */
 
   /*
    * Create a tempfile for writing the new env.  Use the canonicalized filename
    * for the template so that the tmpfile is in the same dir / on same fs.
+   *
+   * We now use per-user fixed temporary filenames, so that a user cannot cause
+   * multiple files to accumulate.
+   *
+   * We don't use O_EXCL so that a stale temporary file doesn't prevent further
+   * usage of the program by the user.
    */
-  snprintf(tmp_filename, sizeof(tmp_filename), "%sXXXXXX", env_filename);
-  fd = mkstemp(tmp_filename);
+  snprintf(tmp_filename, sizeof(tmp_filename), "%s.%u", env_filename, getuid());
+  fd = open(tmp_filename, O_CREAT | O_WRONLY, 0600);
   if (fd == -1)
     {
       perror ("Creating tmpfile failed");
       return 1;
     }
+
+  /*
+   * The lock prevents the same user from reaching further steps ending in
+   * rename() concurrently, in which case the temporary file only partially
+   * written by one invocation could be renamed to the target file by another.
+   *
+   * The lock also guards the slow fsync() from concurrent calls.  After the
+   * first time that and the rename() complete, further invocations for the
+   * same flag become no-ops.
+   *
+   * We lock the temporary file rather than the target file because locking the
+   * latter would allow any user having SIGSTOP'ed their process to make all
+   * other users' invocations fail (or lock up if we'd use blocking mode).
+   *
+   * We use non-blocking mode (LOCK_NB) because the lock having been taken by
+   * another process implies that the other process would normally have already
+   * renamed the file to target by the time it releases the lock (and we could
+   * acquire it), so we'd be working directly on the target if we proceeded,
+   * which is undesirable, and we'd kind of fail on the already-done rename.
+   */
+  if (flock(fd, LOCK_EX | LOCK_NB))
+    {
+      perror ("Locking tmpfile failed");
+      return 1;
+    }
+
+  /*
+   * Deal with the potential that another invocation proceeded all the way to
+   * rename() and process exit while we were between open() and flock().
+   */
+  {
+    struct stat st1, st2;
+    if (fstat(fd, &st1) || stat(tmp_filename, &st2))
+      {
+        perror ("stat of tmpfile failed");
+        return 1;
+      }
+    if (st1.st_dev != st2.st_dev || st1.st_ino != st2.st_ino)
+      {
+        fprintf (stderr, "Another invocation won race\n");
+        return 1;
+      }
+  }
 
   f = fdopen (fd, "w");
   if (!f)
@@ -213,6 +274,14 @@ int main(int argc, char *argv[])
       return 1;     
     }
 
+  ret = ftruncate (fileno (f), GRUBENV_SIZE);
+  if (ret)
+    {
+      perror ("Error truncating tmpfile");
+      unlink(tmp_filename);
+      return 1;
+    }
+
   ret = fsync (fileno (f));
   if (ret)
     {
@@ -221,15 +290,9 @@ int main(int argc, char *argv[])
       return 1;
     }
 
-  ret = fclose (f);
-  if (ret)
-    {
-      perror ("Error closing tmpfile");
-      unlink(tmp_filename);
-      return 1;
-    }
-
   /*
+   * We must not close the file before rename() as that would remove the lock.
+   *
    * And finally rename the tmpfile with the new env over the old env, the
    * linux kernel guarantees that this is atomic (from a syscall pov).
    */

--- a/util/grub-set-bootflag.c
+++ b/util/grub-set-bootflag.c
@@ -99,6 +99,17 @@ int main(int argc, char *argv[])
   len = strlen (bootflag);
 
   /*
+   * Exit calmly when not installed SUID root and invoked by non-root.  This
+   * allows installing user/grub-boot-success.service unconditionally while
+   * supporting non-SUID installation of the program for some limited usage.
+   */
+  if (geteuid())
+    {
+      printf ("grub-set-bootflag not running as root, no action taken\n");
+      return 0;
+    }
+
+  /*
    * setegid avoids the new grubenv's gid being that of the user.
    */
   if (setegid(0))

--- a/util/grub.d/10_linux.in
+++ b/util/grub.d/10_linux.in
@@ -265,8 +265,12 @@ if [ -z "\${kernelopts}" ]; then
 fi
 EOF
 
-  if [ "x${GRUB_UPDATE_BLS_CMDLINE}" = "xyes" ]; then
-      update_bls_cmdline
+  if [ "x${GRUB_UPDATE_BLS_CMDLINE}" = "xyes" ] || [[ -d /run/install ]]; then
+      # only update the bls cmdline if the user specifically requests it or _anytime_
+      # in the installer environment: /run/install directory only exists during the
+      # installation and not in cloud images, so this should get all the boot params
+      # from /etc/default/grub into BLS snippets
+       update_bls_cmdline
   fi
 
   if [ "x${BLS_POPULATE_MENU}" = "xtrue" ]; then


### PR DESCRIPTION
The following patches already tracked at dist-git are now included at git repo

```
APPLIED: 0328-grub2-mkconfig-Pass-all-boot-params-when-used-by-ana.patch
APPLIED: 0329-kern-ieee1275-init-ppc64-Restrict-high-memory-in-pre.patch
APPLIED: 0330-normal-Remove-grub_env_set-prefix-in-grub_try_normal.patch
APPLIED: 0331-search-command-add-flag-to-only-search-root-dev.patch
APPLIED: 0332-grub-set-bootflag-Conservative-partial-fix-for-CVE-2.patch
APPLIED: 0333-grub-set-bootflag-More-complete-fix-for-CVE-2024-104.patch
APPLIED: 0334-grub-set-bootflag-Exit-calmly-when-not-running-as-ro.patch
APPLIED: 0335-fs-ntfs-Fix-an-OOB-write-when-parsing-the-ATTRIBUTE_.patch
APPLIED: 0336-fs-ntfs-Fix-an-OOB-read-when-reading-data-from-the-r.patch
APPLIED: 0337-fs-ntfs-Fix-an-OOB-read-when-parsing-directory-entri.patch
APPLIED: 0338-fs-ntfs-Fix-an-OOB-read-when-parsing-bitmaps-for-ind.patch
APPLIED: 0339-fs-ntfs-Fix-an-OOB-read-when-parsing-a-volume-label.patch
APPLIED: 0340-fs-ntfs-Make-code-more-readable.patch
APPLIED: 0341-grub_dl_set_mem_attrs-fix-format-string.patch
APPLIED: 0342-grub_dl_set_mem_attrs-add-self-check-for-the-tramp-G.patch
APPLIED: 0343-grub_dl_load_segments-page-align-the-tramp-GOT-areas.patch
APPLIED: 0344-grub-install-on-EFI-if-forced.patch
```

Note that patch `0328-grub2-mkconfig-Pass-all-boot-params-when-used-by-ana.patch` is not exactly the same as the dist-git counterpart because these two previously applied differ

```
dist-git: https://pkgs.devel.redhat.com/cgit/rpms/grub2/tree/0327-grub-mkconfig-dont-overwrite-BLS-cmdline-if-BLSCFG.patch?h=rhel-9-main
git: https://github.com/rhboot/grub2/commit/ea9a065f6fb8e01ac0f915a2d7bdb885cfdb52e6
```

This is not a real problem, now both HEADs should have the same content.

