### PR TITLE
Fix build issues caused by -Wsign-compare and -Wincompatible-pointer-…

### DIFF
--- a/grub-core/net/bootp.c
+++ b/grub-core/net/bootp.c
@@ -1053,7 +1053,7 @@ grub_dhcp6_session_add (struct grub_net_network_level_interface *iface,
   grub_dhcp6_session_t se;
   struct grub_datetime date;
   grub_err_t err;
-  grub_int32_t t = 0;
+  grub_int64_t t = 0;
 
   se = grub_malloc (sizeof (*se));
 

--- a/grub-core/net/drivers/efi/efinet.c
+++ b/grub-core/net/drivers/efi/efinet.c
@@ -851,12 +851,12 @@ grub_efi_net_config_real (grub_efi_handle_t hnd, char **device,
       {
 	grub_dprintf ("efinet", "using ipv4 and dhcp\n");
 
-        struct grub_net_bootp_packet *dhcp_ack = &pxe_mode->dhcp_ack;
+        struct grub_net_bootp_packet *dhcp_ack = (struct grub_net_bootp_packet *) &pxe_mode->dhcp_ack;
 
         if (pxe_mode->proxy_offer_received)
           {
             grub_dprintf ("efinet", "proxy offer receive");
-            struct grub_net_bootp_packet *proxy_offer = &pxe_mode->proxy_offer;
+            struct grub_net_bootp_packet *proxy_offer = (struct grub_net_bootp_packet *) &pxe_mode->proxy_offer;
 
             if (proxy_offer && dhcp_ack->boot_file[0] == '\0')
               {

--- a/grub-core/net/http.c
+++ b/grub-core/net/http.c
@@ -414,7 +414,7 @@ http_establish (struct grub_file *file, grub_off_t offset, int initial)
   grub_memcpy (ptr, "\r\n", 2);
 
   grub_dprintf ("http", "opening path %s on host %s TCP port %d\n",
-		data->filename, server, port ? port : HTTP_PORT);
+		data->filename, server, port ? port : (int) HTTP_PORT);
   data->sock = grub_net_tcp_open (server,
 				  port ? port : HTTP_PORT, http_receive,
 				  http_err, NULL,


### PR DESCRIPTION
…types

    In file included from ../../grub-core/net/http.c:19:
    ../../grub-core/net/http.c: In function ‘http_establish’:
    ../../grub-core/net/http.c:417:48: warning: operand of ‘?:’ changes signedness from ‘int’ to ‘enum <anonymous>’ due to unsignedness of other operand [-Wsign-compare]
      417 |                 data->filename, server, port ? port : HTTP_PORT);
          |                                                ^~~~

    ../../grub-core/net/bootp.c: In function ‘grub_dhcp6_session_add’:
    ../../grub-core/net/bootp.c:1061:46: error: passing argument 2 of ‘grub_datetime2unixtime’ from incompatible pointer type [-Wincompatible-pointer-types]
     1061 |   if (err || !grub_datetime2unixtime (&date, &t))
          |                                              ^~
          |                                              |
          |                                              grub_int32_t * {aka int *}

    In file included from ../../grub-core/net/bootp.c:27:
    ../../include/grub/datetime.h:55:77: note: expected ‘grub_int64_t *’ {aka ‘long int *’} but argument is of type ‘grub_int32_t *’ {aka ‘int *’}
       55 | grub_datetime2unixtime (const struct grub_datetime *datetime, grub_int64_t *nix)
          |                                                               ~~~~~~~~~~~~~~^~~

    ../../grub-core/net/drivers/efi/efinet.c: In function ‘grub_efi_net_config_real’:
    ../../grub-core/net/drivers/efi/efinet.c:854:50: error: initialization of ‘struct grub_net_bootp_packet *’ from incompatible pointer type ‘grub_efi_pxe_packet_t *’ [-Wincompatible-pointer-types]
      854 |         struct grub_net_bootp_packet *dhcp_ack = &pxe_mode->dhcp_ack;
          |                                                  ^

    ../../grub-core/net/drivers/efi/efinet.c:859:57: error: initialization of ‘struct grub_net_bootp_packet *’ from incompatible pointer type ‘grub_efi_pxe_packet_t *’ [-Wincompatible-pointer-types]
      859 |             struct grub_net_bootp_packet *proxy_offer = &pxe_mode->proxy_offer;
          |                                                         ^

    ../../grub-core/net/drivers/efi/efinet.c: In function ‘grub_efi_net_config_real’:
    ../../grub-core/net/drivers/efi/efinet.c:859:57: error: initialization of ‘struct grub_net_bootp_packet *’ from incompatible pointer type ‘grub_efi_pxe_packet_t *’ [-Wincompatible-pointer-types]
      859 |             struct grub_net_bootp_packet *proxy_offer = &pxe_mode->proxy_offer;
          |                                                         ^