### PR TITLE
skip empty lines in entry file

### DIFF
--- a/grub-core/commands/blscfg.c
+++ b/grub-core/commands/blscfg.c
@@ -538,7 +538,7 @@ static int read_entry (
       char *separator;
 
       buf = grub_file_getline (f);
-      if (!buf)
+      if (!buf && grub_errno)
 	break;
 
       while (buf && buf[0] && (buf[0] == ' ' || buf[0] == '\t'))


### PR DESCRIPTION
grub_file_getline() doesn't make any distinction between empty lines or EOF, so the following entry:

    title Fedora Linux (6.10.0-matteo) 40 (KDE Plasma)
    version 6.10.0-matteo
    linux /boot/vmlinuz-6.10.0-matteo

    options root=/dev/nvme0n1p2 ro cgroup_no_v1=all

boots the kernel with an empty command line.
Fix this by also checking grub_errno, which correctly signals the EOF.