### PR TITLE
Stop grub.efi from always printing "dynamic_load_symbols %p\n" during…

### DIFF
--- a/grub-core/kern/efi/debug.c
+++ b/grub-core/kern/efi/debug.c
@@ -26,7 +26,7 @@ grub_cmd_gdbinfo (struct grub_command *cmd __attribute__ ((unused)),
 		  int argc __attribute__ ((unused)),
 		  char **args __attribute__ ((unused)))
 {
-  grub_efi_print_gdb_info ();
+  grub_efi_print_gdb_info (false);
   return 0;
 }
 

--- a/grub-core/kern/efi/init.c
+++ b/grub-core/kern/efi/init.c
@@ -157,7 +157,7 @@ grub_efi_init (void)
   grub_efi_system_table->boot_services->set_watchdog_timer (0, 0, 0, NULL);
 
   grub_efi_env_init ();
-  grub_efi_print_gdb_info ();
+  grub_efi_print_gdb_info (true);
   grub_efidisk_init ();
 
   grub_efi_register_debug_commands ();

--- a/grub-core/loader/efi/linux.c
+++ b/grub-core/loader/efi/linux.c
@@ -236,6 +236,7 @@ grub_efi_linux_boot (grub_addr_t k_address, grub_size_t k_size,
   grub_dprintf ("linux", "kernel_address: %p handover_offset: %p params: %p\n",
 		(void *)k_address, (void *)h_offset, k_params);
 
+  grub_efi_check_nx_required(&nx_required);
 
   if (nx_required && !nx_supported)
     return grub_error (GRUB_ERR_BAD_OS, N_("kernel does not support NX loading required by policy"));

--- a/include/grub/efi/debug.h
+++ b/include/grub/efi/debug.h
@@ -27,7 +27,7 @@
 void grub_efi_register_debug_commands (void);
 
 static inline void
-grub_efi_print_gdb_info (void)
+grub_efi_print_gdb_info (bool debug)
 {
   grub_addr_t text;
 
@@ -35,7 +35,10 @@ grub_efi_print_gdb_info (void)
   if (!text)
     return;
 
-  grub_printf ("dynamic_load_symbols %p\n", (void *)text);
+  if (debug)
+    grub_qdprintf ("gdb", "dynamic_load_symbols %p\n", (void *)text);
+  else
+    grub_printf ("dynamic_load_symbols %p\n", (void *)text);
 }
 
 #endif /* ! GRUB_EFI_DEBUG_HEADER */


### PR DESCRIPTION
… boot

Commit 972aa68d2bf5 ("Make a "gdb" dprintf that tells us load addresses.") added some debug prints to help with running gdb against grub.

Besides adding a new grub_dl_print_gdb_info () function which uses `grub_qdprintf ("gdb", ...);` it also adds a new grub_efi_print_gdb_info () call to grub_efi_init ().

grub_efi_print_gdb_info () is intended for the gdbinfo command and uses a non debug grub_printf () call leading to grub now always printing this message during boot breaking flicker-free boot.

Add a new "debug" parameter to grub_efi_print_gdb_info () and use `grub_qdprintf ("gdb", ...);` when this is set to silence the printing done from grub_efi_init () when debugging is not enabled.

Fixes: 972aa68d2bf5 ("Make a "gdb" dprintf that tells us load addresses.")