### PR TITLE
Fix the fallback mechanism when menu entries fail to boot

### DIFF
--- a/grub-core/normal/menu.c
+++ b/grub-core/normal/menu.c
@@ -377,14 +377,14 @@ grub_menu_execute_entry(grub_menu_entry_t entry, int auto_boot)
   if (ptr && ptr[0] && ptr[1])
     grub_env_set ("default", ptr + 1);
 
-  grub_script_execute_new_scope (entry->sourcecode, entry->argc, entry->args);
+  err = grub_script_execute_new_scope (entry->sourcecode, entry->argc, entry->args);
 
   if (errs_before != grub_err_printed_errors)
     grub_wait_after_message ();
 
   errs_before = grub_err_printed_errors;
 
-  if (grub_errno == GRUB_ERR_NONE && grub_loader_is_loaded ())
+  if (err == GRUB_ERR_NONE && grub_loader_is_loaded ())
     /* Implicit execution of boot, only if something is loaded.  */
     err = grub_command_execute ("boot", 0, 0);
 

--- a/grub-core/script/execute.c
+++ b/grub-core/script/execute.c
@@ -952,7 +952,10 @@ grub_script_execute_sourcecode (const char *source)
 	  break;
 	}
 
-      ret = grub_script_execute (parsed_script);
+      /* Don't let trailing blank lines determine the return code.  */
+      if (parsed_script->cmd)
+	ret = grub_script_execute (parsed_script);
+
       grub_script_free (parsed_script);
       grub_free (line);
     }

--- a/tests/grub_script_eval.in
+++ b/tests/grub_script_eval.in
@@ -4,3 +4,11 @@ eval echo "Hello world"
 valname=tst
 eval $valname=hi
 echo $tst
+
+if eval "
+false
+"; then
+  echo should have failed
+else
+  echo failed as expected
+fi


### PR DESCRIPTION
@martinezjavier's c3fcfe5942e36348ad8e5eb24fd584705e00c06f commit accidentally broke the fallback mechanism, although it also exposed another bug in upstream GRUB.

We cannot rely on `grub_errno` in `grub_menu_execute_entry()` because `grub_script_execute_new_scope()` calls `grub_print_error()`, which always resets `grub_errno` back to `GRUB_ERR_NONE`. It may also get reset by `grub_wait_after_message()`.

`grub_script_execute_sourcecode()` parses and executes code one line at a time, updating the return code each time because only the last line determines the final status. However, trailing new lines were also executed, masking any failure on the previous line. Fix this by only trying to execute the command when there is actually one present. A new test case is included.

See the commit messages for further details.

~~I can send the first change upstream, although it's unlikely to cause issues without your change, hence why it went unnoticed for so long. I gather you are starting to upstream some of your changes, so perhaps I can leave it with you?~~