### PR TITLE
Fix RISC-V support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1313,7 +1313,7 @@ AC_SUBST(TARGET_LDFLAGS_OLDMAGIC)
 
 LDFLAGS="$TARGET_LDFLAGS"
 
-if test "$target_cpu" = x86_64 || test "$target_cpu" = sparc64 || test "$target_cpu" = riscv64 ; then
+if test "$target_cpu" = x86_64 || test "$target_cpu" = sparc64 ; then
   # Use large model to support 4G memory
   AC_CACHE_CHECK([whether option -mcmodel=large works], grub_cv_cc_mcmodel, [
     CFLAGS="$TARGET_CFLAGS -mcmodel=large"
@@ -1323,9 +1323,11 @@ if test "$target_cpu" = x86_64 || test "$target_cpu" = sparc64 || test "$target_
   ])
   if test "x$grub_cv_cc_mcmodel" = xyes; then
     TARGET_CFLAGS="$TARGET_CFLAGS -mcmodel=large"
-  elif test "$target_cpu" = sparc64 || test "$target_cpu" = riscv64; then
+  elif test "$target_cpu" = sparc64; then
     TARGET_CFLAGS="$TARGET_CFLAGS -mcmodel=medany"
   fi
+elif test "$target_cpu" = riscv64 ; then
+    TARGET_CFLAGS="$TARGET_CFLAGS -mcmodel=medany"
 fi
 
 if test "$target_cpu"-"$platform" = x86_64-efi; then

--- a/grub-core/kern/riscv/efi/init.c
+++ b/grub-core/kern/riscv/efi/init.c
@@ -33,16 +33,15 @@ grub_efi_get_time_ms (void)
   grub_uint64_t tmr;
 
 #if __riscv_xlen == 64
-  asm volatile ("rdcycle %0" : "=r" (tmr));
+  asm volatile ("rdtime %0" : "=r"(tmr));
 #else
   grub_uint32_t lo, hi, tmp;
-  asm volatile (
-    "1:\n"
-    "rdcycleh %0\n"
-    "rdcycle %1\n"
-    "rdcycleh %2\n"
-    "bne %0, %2, 1b"
-    : "=&r" (hi), "=&r" (lo), "=&r" (tmp));
+  asm volatile ("1:\n"
+                "rdtimeh %0\n"
+                "rdtime %1\n"
+                "rdtimeh %2\n"
+                "bne %0, %2, 1b"
+                : "=&r" (hi), "=&r" (lo), "=&r" (tmp));
   tmr = ((grub_uint64_t)hi << 32) | lo;
 #endif
 

--- a/grub-core/loader/efi/linux.c
+++ b/grub-core/loader/efi/linux.c
@@ -684,7 +684,7 @@ parse_pe_header (void *kernel, grub_uint64_t *total_size,
 		 grub_uint32_t *alignment, grub_uint32_t *code_size)
 {
   struct linux_arch_kernel_header *lh = kernel;
-  struct grub_armxx_linux_pe_header *pe;
+  struct grub_efixx_linux_pe_header *pe;
   grub_uint16_t i;
   struct grub_pe32_section_table *sections;
 

--- a/include/grub/efi/efi.h
+++ b/include/grub/efi/efi.h
@@ -36,28 +36,28 @@ struct linux_arch_kernel_header {
   struct grub_pe_image_header pe_image_header;
 };
 
-struct grub_arm_linux_pe_header
+struct grub_efi32_linux_pe_header
 {
   grub_uint32_t magic;
   struct grub_pe32_coff_header coff;
   struct grub_pe32_optional_header opt;
 };
 
-struct grub_arm64_linux_pe_header
+struct grub_efi64_linux_pe_header
 {
   grub_uint32_t magic;
   struct grub_pe32_coff_header coff;
   struct grub_pe64_optional_header opt;
 };
 
-#if defined(__arm__)
+#if defined(__arm__) || (defined(__riscv) && (__riscv_xlen == 32))
 # define GRUB_PE32_PEXX_MAGIC GRUB_PE32_PE32_MAGIC
-# define grub_armxx_linux_pe_header grub_arm_linux_pe_header
+# define grub_efixx_linux_pe_header grub_efi32_linux_pe_header
 #endif
 
-#if defined(__aarch64__)
+#if defined(__aarch64__) || (defined(__riscv) && (__riscv_xlen == 64))
 # define GRUB_PE32_PEXX_MAGIC GRUB_PE32_PE64_MAGIC
-# define grub_armxx_linux_pe_header grub_arm64_linux_pe_header
+# define grub_efixx_linux_pe_header grub_efi64_linux_pe_header
 #endif
 
 #define GRUB_EFI_GRUB_VARIABLE_GUID             \


### PR DESCRIPTION
This PR adds three patches that, together, make grub2 build and work on riscv64.

Specifically:

* the first commit tweaks some of the code not present upstream so that it builds at all;
* the second one is a backport of post-2.12 upstream commit c5ae124e11f28f637cbd38cb4d6c1b9817baa135;
* the third one switches from large model, which doesn't work when building with GCC 14, to medany (upstream bug [65909](https://savannah.gnu.org/bugs/?65909)).

The changes have been tested by building the package and using it to boot Fedora 41, both in a VM and on real hardware (StarFive VisionFive 2 board).