### PR TITLE
Enable building blscfg module on xen and xen_pvh

### DIFF
--- a/grub-core/Makefile.core.def
+++ b/grub-core/Makefile.core.def
@@ -880,6 +880,8 @@ module = {
   enable = efi;
   enable = i386_pc;
   enable = emu;
+  enable = xen;
+  enable = i386_xen_pvh;
 };
 
 module = {


### PR DESCRIPTION
Building blscfg module for Xen targets makes it possible to include them in custom pvgrub2 and pvhgrub2 images. Those are then used to boot PV and PVH domUs.