### PR TITLE
feat(hello): modify hello command and add greet command

### DIFF
--- a/grub-core/hello/hello.c
+++ b/grub-core/hello/hello.c
@@ -33,19 +33,32 @@ grub_cmd_hello (grub_extcmd_context_t ctxt __attribute__ ((unused)),
 		int argc __attribute__ ((unused)),
 		char **args __attribute__ ((unused)))
 {
-  grub_printf ("%s\n", _("Hello World"));
+  grub_printf ("%s\n", _("Hello GRUB User!"));
+  return 0;
+}
+
+static grub_err_t
+grub_cmd_greet (grub_extcmd_context_t ctxt __attribute__ ((unused)),
+		int argc __attribute__ ((unused)),
+		char **args __attribute__ ((unused)))
+{
+  grub_printf ("%s\n", _("Greetings from GRUB!"));
   return 0;
 }
 
 static grub_extcmd_t cmd;
+static grub_extcmd_t greet_cmd;
 
 GRUB_MOD_INIT(hello)
 {
   cmd = grub_register_extcmd ("hello", grub_cmd_hello, 0, 0,
-			      N_("Say `Hello World'."), 0);
+			      N_("Say `Hello GRUB User!'."), 0);
+  greet_cmd = grub_register_extcmd ("greet", grub_cmd_greet, 0, 0,
+			      N_("Display a friendly greeting."), 0);
 }
 
 GRUB_MOD_FINI(hello)
 {
   grub_unregister_extcmd (cmd);
+  grub_unregister_extcmd (greet_cmd);
 }


### PR DESCRIPTION
this commit introduces the following conceptual changes to grub-core/hello/hello.c:

1.  modified the existing `hello` command to print "hello grub user!" instead of "hello world!". the help text for the command has also been updated.
2.  added a new command `greet` that prints "greetings from grub!". this includes the command function, registration, and unregistration.

IMPORTANT: These code changes have NOT been compiled or tested. Attempts to build the GRUB project failed due to persistent internal errors during the `./bootstrap` step and even during attempts to install dependencies. These environment issues prevented any verification of the code.