### PR TITLE
Fix issues with RAID1 metadata 1.0 partitions on IEEE1275

### DIFF
--- a/grub-core/disk/mdraid1x_linux.c
+++ b/grub-core/disk/mdraid1x_linux.c
@@ -130,7 +130,7 @@ grub_mdraid_detect (grub_disk_t disk,
       struct grub_diskfilter_vg *array;
       char *uuid;
 
-#ifdef __powerpc__
+#if defined(__powerpc__) && !defined(GRUB_UTIL)
       /* Firmware will yell at us for reading too far. */
       if (minor_version == 0)
         continue;

--- a/grub-core/disk/mdraid_linux.c
+++ b/grub-core/disk/mdraid_linux.c
@@ -189,7 +189,7 @@ grub_mdraid_detect (grub_disk_t disk,
   grub_uint32_t level;
   struct grub_diskfilter_vg *ret;
 
-#ifdef __powerpc__
+#if defined(__powerpc__) && !defined(GRUB_UTIL)
   /* Firmware will yell at us for reading too far. */
   return NULL;
 #endif

--- a/util/grub-install.c
+++ b/util/grub-install.c
@@ -1422,7 +1422,12 @@ main (int argc, char *argv[])
               debug_image);
     }
 
-  if (!have_abstractions)
+  int is_ieee1275_raid1 = have_abstractions
+    && (platform == GRUB_INSTALL_PLATFORM_POWERPC_IEEE1275)
+    && grub_dev->disk
+    && probe_raid_level (grub_dev->disk) == 1;
+
+  if (!have_abstractions || is_ieee1275_raid1)
     {
       if ((disk_module && grub_strcmp (disk_module, "biosdisk") != 0)
 	  || grub_drives[1]


### PR DESCRIPTION
I'm here from https://github.com/coreos/fedora-coreos-tracker/issues/2134, where the relevant context for this PR is in https://github.com/coreos/fedora-coreos-tracker/issues/2134#issuecomment-4379658336.

This PR contains 2 commits, which when combined fix the issue we're encountering with metadata 1.0 RAID1 arrays on ppc64le on Fedora CoreOS. Additional context can be found in the comment linked above, and in the individual commits, but for a brief overview (both specific to PowerPC):

1. Avoid skipping detection of metadata 1.0 partitions in userspace utilities, since the skip was only introduced to avoid firmware issues
2. In `grub-install`, use `search.fs_uuid` for RAID1 instead of hard-coding the mduuid prefix, which requires array assembly at boot (and hence can hit the metadata 1.0 skip)

Theoretically these changes should only affect PowerPC RAID1, but I did test that this didn't break boot on x86 or aarch64 (ran our various boot tests with builds including the patched rpm). And with these patches, all our tests pass on PowerPC.

Please let me know if there are any issues, or there are additional checks/tests you would like me to run.