### PR TITLE
grub-get-kernel-settings: Treate kernel-uki-dtbloader as default kernel

### DIFF
--- a/util/grub-get-kernel-settings.in
+++ b/util/grub-get-kernel-settings.in
@@ -68,7 +68,12 @@ if test -f /etc/sysconfig/kernel ; then
     . /etc/sysconfig/kernel
 fi
 
-GRUB_DEFAULT_KERNEL_TYPE=${DEFAULTKERNEL/-core/}
+# kernel-uki-dtbloader is a drop in replacement for kernel-core, treat it as such
+if [ "$DEFAULTKERNEL" = "kernel-uki-dtbloader"  ]; then
+    GRUB_DEFAULT_KERNEL_TYPE="kernel"
+else
+    GRUB_DEFAULT_KERNEL_TYPE=${DEFAULTKERNEL/-core/}
+fi
 if [ "$GRUB_DEFAULT_KERNEL_TYPE" != "kernel" ]; then
     echo GRUB_NON_STANDARD_KERNEL=true
     echo export GRUB_NON_STANDARD_KERNEL


### PR DESCRIPTION
kernel-uki-dtbloader is a drop-in replacement for kernel-core, it even conflicts with kernel-core since it uses identical filenames under /boot.

Before this patch grub-get-kernel-settings handled kernel-uki-dtbloader as a special kernel variant, causing GRUB_NON_STANDARD_KERNEL=true to get set which leads to /lib/kernel/install.d/20-grub.install setting GRUB_UPDATE_DEFAULT_KERNEL=false which results in skipping the grub2-set-default call later on during kernel-install.

As a result of this users of Fedora 44+ ARM64 live media which uses kernel-uki-dtbloader would still get the old kernel on reboot after installing kernel updates (Bug 2463620 - GRUB environment variable saved_entry not updated when installing UKI kernel on F44 aarch64).

Resolve this by treating kernel-uki-dtbloader as default kernel, just like how kernel-core is handled.

Note on the next rebase of rhboot/grub this may be merged into commit c5baa5c1003d ("Add grub-get-kernel-settings and use it in 10_linux")

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2463620
Fixes: c5baa5c1003d ("Add grub-get-kernel-settings and use it in 10_linux")

I'll also submit a https://src.fedoraproject.org/rpms/grub2/ PR for this with the dist-git bits.