### PR TITLE
net/efi/http: match Content-Length case-insensitively

### DIFF
--- a/grub-core/net/efi/http.c
+++ b/grub-core/net/efi/http.c
@@ -321,7 +321,7 @@ efihttp_request (grub_efi_http_t *http, char *server, char *name, int use_https,
       /* parse the length of the file from the ContentLength header */
       for (*file_size = 0, i = 0; i < (int)response_message.header_count; ++i)
 	{
-	  if (!grub_strcmp((const char*)response_message.headers[i].field_name, "Content-Length"))
+	  if (!grub_strcasecmp((const char*)response_message.headers[i].field_name, "Content-Length"))
 	    {
 	      *file_size = grub_strtoul((const char*)response_message.headers[i].field_value, 0, 10);
 	      break;


### PR DESCRIPTION
`efihttp_request()` matches response headers with `grub_strcmp(field_name, "Content-Length")`. RFC 9110 §5.1 makes field names case-insensitive, and modern servers (any hyper/Rust-based stack, h2-normalized proxies) emit `content-length`. When the match fails the transfer size stays 0 and every fetch over UEFI HTTP(S) boot silently returns a zero-length file — grub.cfg reads as empty, kernel/initrd load as empty, no error reported anywhere, which makes this very hard to diagnose in the field.

Observed on real hardware: Rocky Linux 10 shim+grub under UEFI HTTPS Boot against a hyper-based HTTP server. Forcing title-case headers server-side makes the same boot succeed, confirming the diagnosis.

Fix: `grub_strcasecmp`. One line.
